### PR TITLE
dev server proxy config to localhost:8080/

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -65,6 +65,9 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "proxyConfig": "src/proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "browserTarget": "pomagamukrainie:build:production"

--- a/src/proxy.conf.json
+++ b/src/proxy.conf.json
@@ -1,0 +1,6 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false
+  }
+}


### PR DESCRIPTION
So that this works in dev mode (when you have the server started with `./start_server.sh` from https://github.com/coi-gov-pl/pomocua-ogloszenia):
```
  constructor(private http: HttpClient) {}

  foo() {
    this.http.get('/api/jobs').subscribe(console.log);
  }
```