### PR TITLE
Hotfix: Delete an import to a non-existing header.module

### DIFF
--- a/src/app/welcome/welcome.module.ts
+++ b/src/app/welcome/welcome.module.ts
@@ -7,7 +7,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
 import { CategoryNavigationComponentModule } from './category-navigation/category-navigation.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
-import { HeaderModule } from '../header/header.module';
 
 @NgModule({
   declarations: [WelcomeComponent, DashboardComponent],
@@ -18,7 +17,6 @@ import { HeaderModule } from '../header/header.module';
     WelcomeRoutingModule,
     MatIconModule,
     TranslateModule,
-    HeaderModule,
   ],
 })
 export class WelcomeModule {}


### PR DESCRIPTION
This is needed to unbreak the build; without it, it's impossible to run the dev
server so also to work on the app.

The import can be re-added later together with the referenced file but for now
this is necessary to unbreak the build for everyone.