### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce UNIX line endings for tools like Prettier to work
+* text=auto eol=lf


### PR DESCRIPTION
Enforce UNIX line endings for tools like Prettier to work.

See https://prettier.io/docs/en/options.html#end-of-line

Per the above link, the only caveat is:
> You may need to ask Windows users to re-clone your repo after this change to ensure git has not converted LF to CRLF on checkout.