### PR TITLE
POM-75 Transport views + some shared component fixes/additions

### DIFF
--- a/src/app/core/translations/pl_PL.ts
+++ b/src/app/core/translations/pl_PL.ts
@@ -63,4 +63,6 @@ export default {
   LABEL_LENGTH_OF_STAY: 'Czas pobytu',
   LABEL_HOST_LANG: 'Język, w jakim mówi gospodarz:',
   MAIN_PAGE: 'Strona Główna',
+  EG_RZESZOW_PODKARPACKIE: 'Np. Rzeszów, podkarpackie',
+  EG_WARSZAWA_MAZOWIECKIE: 'Np. Warszawa, mazowieckie',
 };

--- a/src/app/core/translations/pl_PL.ts
+++ b/src/app/core/translations/pl_PL.ts
@@ -63,6 +63,5 @@ export default {
   LABEL_LENGTH_OF_STAY: 'Czas pobytu',
   LABEL_HOST_LANG: 'Język, w jakim mówi gospodarz:',
   MAIN_PAGE: 'Strona Główna',
-  EG_RZESZOW_PODKARPACKIE: 'Np. Rzeszów, podkarpackie',
-  EG_WARSZAWA_MAZOWIECKIE: 'Np. Warszawa, mazowieckie',
+  PLACEHOLDER_LOCATION_2: 'Np. Warszawa, mazowieckie',
 };

--- a/src/app/find-help/find-help.component.ts
+++ b/src/app/find-help/find-help.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { CorePath } from '@app/shared/models/core-path.enum';
+import { CorePath } from '@app/shared/models';
 
 @Component({
   selector: 'app-find-get-help',

--- a/src/app/find-help/material-aid-search/material-aid-search-form/material-aid-search-form.component.html
+++ b/src/app/find-help/material-aid-search/material-aid-search-form/material-aid-search-form.component.html
@@ -15,7 +15,7 @@
         <app-cities-search
           [(ngModel)]="data.location"
           name="location"
-          [placeholder]="'Np. Rzeszów, podkarpackie'"
+          [placeholder]="'EG_RZESZOW_PODKARPACKIE' | translate"
           [label]="'LOCATION' | translate"
         ></app-cities-search>
       </div>

--- a/src/app/find-help/material-aid-search/material-aid-search-form/material-aid-search-form.component.html
+++ b/src/app/find-help/material-aid-search/material-aid-search-form/material-aid-search-form.component.html
@@ -15,7 +15,7 @@
         <app-cities-search
           [(ngModel)]="data.location"
           name="location"
-          [placeholder]="'EG_RZESZOW_PODKARPACKIE' | translate"
+          [placeholder]="'PLACEHOLDER_LOCATION' | translate"
           [label]="'LOCATION' | translate"
         ></app-cities-search>
       </div>

--- a/src/app/find-help/material-aid-search/material-aid-search.module.ts
+++ b/src/app/find-help/material-aid-search/material-aid-search.module.ts
@@ -9,7 +9,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MaterialAidSearchRoutingModule } from './material-aid-search.routing.module';
-import { PomCommonPipesModule } from '../../shared/pipes/pom-common-pipes.module';
+import { PomCommonPipesModule } from '@app/shared/pipes';
 import { TranslateModule } from '@ngx-translate/core';
 import { MaterialAidSearchComponent } from './material-aid-search.component';
 import { SearchResultComponentModule } from '../search-result/search-result.module';

--- a/src/app/find-help/search-result/search-result-attribute/search-result-attribute.component.html
+++ b/src/app/find-help/search-result/search-result-attribute/search-result-attribute.component.html
@@ -1,2 +1,3 @@
 <mat-icon fontSet="material-icons-outlined">{{ icon }}</mat-icon>
-{{ text }}
+<span *ngIf="text">{{ text }}</span>
+<ng-content></ng-content>

--- a/src/app/find-help/search-result/search-result-attribute/search-result-attribute.component.scss
+++ b/src/app/find-help/search-result/search-result-attribute/search-result-attribute.component.scss
@@ -1,7 +1,13 @@
-mat-icon {
+:host {
+  display: flex;
+  align-items: center;
+}
+
+.mat-icon {
   font-size: var(--attribute-font-size);
   width: var(--attribute-font-size);
   height: var(--attribute-font-size);
   opacity: 1;
   color: var(--c-yellow);
+  margin-right: 0.5em;
 }

--- a/src/app/find-help/search-result/search-result-attribute/search-result-attribute.component.ts
+++ b/src/app/find-help/search-result/search-result-attribute/search-result-attribute.component.ts
@@ -7,7 +7,7 @@ import { Component, Input } from '@angular/core';
 })
 export class SearchResultAttributeComponent {
   @Input()
-  text?: string;
+  text: string | null | undefined;
   @Input()
-  icon?: string;
+  icon: string | null | undefined;
 }

--- a/src/app/find-help/search-result/search-result.component.html
+++ b/src/app/find-help/search-result/search-result.component.html
@@ -1,10 +1,16 @@
 <mat-card class="result">
   <div class="attributes">
-    <div *ngIf="location">
-      <mat-icon fontSet="material-icons-outlined">location_on</mat-icon>
-      {{ location.city }}
-    </div>
-    <div class="right" *ngIf="posted">{{ postedDate | date: "short" }}</div>
+    <app-search-result-attribute
+      *ngIf="location && !destination"
+      [text]="location.city"
+      icon="location_on"
+    ></app-search-result-attribute>
+    <app-search-result-attribute *ngIf="location && destination" icon="location_on">
+      <span class="text-with-icon"
+        >{{ location.city }} <mat-icon fontSet="material-icons-outlined">east</mat-icon> {{ destination.city }}</span
+      >
+    </app-search-result-attribute>
+    <div class="right" *ngIf="posted">{{ postedDate | date }}</div>
   </div>
   <h4>{{ title }}</h4>
   <div class="attributes">

--- a/src/app/find-help/search-result/search-result.component.scss
+++ b/src/app/find-help/search-result/search-result.component.scss
@@ -1,12 +1,19 @@
 .result {
   font-family: var(--font-roboto);
   margin-bottom: 11px;
+  mat-icon {
+    font-size: var(--attribute-font-size);
+    width: var(--attribute-font-size);
+    height: var(--attribute-font-size);
+    opacity: 1;
+    color: var(--c-yellow);
+  }
   .attributes {
-    --attribute-font-size: 12px;
+    --attribute-font-size: 13px;
     font-family: var(--font-roboto);
     margin: 0 0 11px 0;
     opacity: 0.5;
-    font-size: 12px;
+    font-size: var(--attribute-font-size);
     display: flex;
     gap: 18px;
     .right {
@@ -21,5 +28,15 @@
   .description {
     font-size: 15px;
     color: var(--c-darkblue);
+  }
+  .text-with-icon {
+    display: flex;
+    align-items: center;
+
+    .mat-icon {
+      margin-left: 0.5em;
+      margin-right: 0.5em;
+      color: inherit;
+    }
   }
 }

--- a/src/app/find-help/search-result/search-result.component.ts
+++ b/src/app/find-help/search-result/search-result.component.ts
@@ -20,12 +20,14 @@ export class SearchResultComponent implements OnChanges {
 
   postedDate: Date | undefined;
 
-  ngOnChanges({ posted }: SimpleChanges) {
-    const postedVal = posted.currentValue;
-    if (postedVal === undefined || postedVal instanceof Date) {
-      this.postedDate = postedVal;
-    } else {
-      this.postedDate = new Date(postedVal);
+  ngOnChanges({ posted, location, destination }: SimpleChanges) {
+    if (posted) {
+      const postedVal = posted.currentValue;
+      if (postedVal === undefined || postedVal instanceof Date) {
+        this.postedDate = postedVal;
+      } else {
+        this.postedDate = new Date(postedVal);
+      }
     }
   }
 }

--- a/src/app/find-help/transport-search/transport-search-form/transport-search-form.component.html
+++ b/src/app/find-help/transport-search/transport-search-form/transport-search-form.component.html
@@ -5,7 +5,7 @@
         <app-cities-search
           [(ngModel)]="data.origin"
           name="origin"
-          [placeholder]="'Np. Rzeszów, podkarpackie'"
+          [placeholder]="'EG_RZESZOW_PODKARPACKIE' | translate"
           [label]="'LOCATION_FROM' | translate"
         ></app-cities-search>
       </div>
@@ -13,7 +13,7 @@
         <app-cities-search
           [(ngModel)]="data.destination"
           name="destination"
-          [placeholder]="'Np. Warszawa, mazowieckie'"
+          [placeholder]="'EG_WARSZAWA_MAZOWIECKIE' | translate"
           [label]="'LOCATION_TO' | translate"
         ></app-cities-search>
       </div>
@@ -21,17 +21,7 @@
         <label
           ><b>{{ "DATE" | translate }}</b></label
         >
-        <mat-form-field appearance="outline">
-          <input
-            matInput
-            [(ngModel)]="data.transportDate"
-            [matDatepicker]="picker"
-            name="transportDate"
-            [placeholder]="'Wybierz datę'"
-          />
-          <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-          <mat-datepicker #picker></mat-datepicker>
-        </mat-form-field>
+        <app-datepicker [(date)]="data.transportDate"></app-datepicker>
       </div>
       <div class="col-md-1">
         <label

--- a/src/app/find-help/transport-search/transport-search-form/transport-search-form.component.html
+++ b/src/app/find-help/transport-search/transport-search-form/transport-search-form.component.html
@@ -5,7 +5,7 @@
         <app-cities-search
           [(ngModel)]="data.origin"
           name="origin"
-          [placeholder]="'EG_RZESZOW_PODKARPACKIE' | translate"
+          [placeholder]="'PLACEHOLDER_LOCATION' | translate"
           [label]="'LOCATION_FROM' | translate"
         ></app-cities-search>
       </div>
@@ -13,7 +13,7 @@
         <app-cities-search
           [(ngModel)]="data.destination"
           name="destination"
-          [placeholder]="'EG_WARSZAWA_MAZOWIECKIE' | translate"
+          [placeholder]="'PLACEHOLDER_LOCATION_2' | translate"
           [label]="'LOCATION_TO' | translate"
         ></app-cities-search>
       </div>

--- a/src/app/find-help/transport-search/transport-search-form/transport-search-form.component.ts
+++ b/src/app/find-help/transport-search/transport-search-form/transport-search-form.component.ts
@@ -8,6 +8,7 @@ import { TransportOfferSearchCriteria } from '@app/core/api';
 })
 export class TransportSearchFormComponent {
   data: TransportOfferSearchCriteria = {};
+
   @Output()
   search = new EventEmitter<TransportOfferSearchCriteria>();
 }

--- a/src/app/find-help/transport-search/transport-search.component.html
+++ b/src/app/find-help/transport-search/transport-search.component.html
@@ -10,10 +10,11 @@
       [destination]="result.destination"
       [title]="result.title"
       [description]="result.description"
+      [posted]="result.modifiedDate"
     >
       <app-search-result-attribute
         *ngIf="result.transportDate"
-        [text]="result.transportDate"
+        [text]="result.transportDate | date"
         icon="date_range"
       ></app-search-result-attribute>
       <app-search-result-attribute

--- a/src/app/find-help/transport-search/transport-search.module.ts
+++ b/src/app/find-help/transport-search/transport-search.module.ts
@@ -13,7 +13,7 @@ import { TransportSearchComponent } from './transport-search.component';
 import { SearchResultComponentModule } from '../search-result/search-result.module';
 import { CitiesSearchModule, MoreInfoLinkModule } from '@app/shared/components';
 import { TransportSearchFormComponent } from './transport-search-form/transport-search-form.component';
-import { DatepickerModule } from '../../shared/components/datepicker/datepicker.module';
+import { DatepickerModule } from '@app/shared/components';
 
 @NgModule({
   declarations: [TransportSearchComponent, TransportSearchFormComponent],

--- a/src/app/find-help/transport-search/transport-search.module.ts
+++ b/src/app/find-help/transport-search/transport-search.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatNativeDateModule } from '@angular/material/core';
-import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -14,6 +13,7 @@ import { TransportSearchComponent } from './transport-search.component';
 import { SearchResultComponentModule } from '../search-result/search-result.module';
 import { CitiesSearchModule, MoreInfoLinkModule } from '@app/shared/components';
 import { TransportSearchFormComponent } from './transport-search-form/transport-search-form.component';
+import { DatepickerModule } from '../../shared/components/datepicker/datepicker.module';
 
 @NgModule({
   declarations: [TransportSearchComponent, TransportSearchFormComponent],
@@ -23,7 +23,6 @@ import { TransportSearchFormComponent } from './transport-search-form/transport-
     FormsModule,
     ReactiveFormsModule,
     MatCardModule,
-    MatDatepickerModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
@@ -34,6 +33,7 @@ import { TransportSearchFormComponent } from './transport-search-form/transport-
     CitiesSearchModule,
     SearchResultComponentModule,
     MoreInfoLinkModule,
+    DatepickerModule,
   ],
 })
 export class TransportSearchModule {}

--- a/src/app/give-help/transport-form/transport-form.component.html
+++ b/src/app/give-help/transport-form/transport-form.component.html
@@ -56,19 +56,7 @@
           <label
             ><b>{{ "LABEL_DATE" | translate }}</b></label
           >
-          <mat-form-field appearance="outline">
-            <input
-              matInput
-              [(ngModel)]="data.transportDate"
-              [matDatepicker]="picker"
-              [min]="minDate"
-              name="transportDate"
-              placeholder="{{ 'PLACEHOLDER_CHOOSE_DATE' | translate }}"
-              autocomplete="off"
-            />
-            <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-            <mat-datepicker #picker></mat-datepicker>
-          </mat-form-field>
+          <app-datepicker [(date)]="data.transportDate"></app-datepicker>
         </div>
         <div class="col-md-2">
           <label

--- a/src/app/give-help/transport-form/transport-form.module.ts
+++ b/src/app/give-help/transport-form/transport-form.module.ts
@@ -10,7 +10,7 @@ import { TransportFormRoutingModule } from './transport-form.routing.modue';
 import { MatNativeDateModule } from '@angular/material/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
-import { DatepickerModule } from '@app/shared/components/datepicker/datepicker.module';
+import { DatepickerModule } from '@app/shared/components';
 
 @NgModule({
   declarations: [TransportFormComponent],

--- a/src/app/give-help/transport-form/transport-form.module.ts
+++ b/src/app/give-help/transport-form/transport-form.module.ts
@@ -8,9 +8,9 @@ import { MatCardModule } from '@angular/material/card';
 import { TransportFormComponent } from './transport-form.component';
 import { TransportFormRoutingModule } from './transport-form.routing.modue';
 import { MatNativeDateModule } from '@angular/material/core';
-import { MatDatepickerModule } from '@angular/material/datepicker';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
+import { DatepickerModule } from '@app/shared/components/datepicker/datepicker.module';
 
 @NgModule({
   declarations: [TransportFormComponent],
@@ -22,10 +22,10 @@ import { MatIconModule } from '@angular/material/icon';
     MatInputModule,
     TransportFormRoutingModule,
     MatCardModule,
-    MatDatepickerModule,
     MatNativeDateModule,
     TranslateModule,
     MatIconModule,
+    DatepickerModule,
   ],
   exports: [TransportFormComponent],
 })

--- a/src/app/shared/components/datepicker/datepicker.component.html
+++ b/src/app/shared/components/datepicker/datepicker.component.html
@@ -1,0 +1,12 @@
+<mat-form-field appearance="outline">
+  <input
+    matInput
+    [ngModel]="dateModel"
+    (ngModelChange)="onDatePickerChange($event)"
+    [matDatepicker]="picker"
+    name="transportDate"
+    [placeholder]="'PLACEHOLDER_CHOOSE_DATE' | translate"
+  />
+  <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+  <mat-datepicker #picker></mat-datepicker>
+</mat-form-field>

--- a/src/app/shared/components/datepicker/datepicker.component.spec.ts
+++ b/src/app/shared/components/datepicker/datepicker.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DatepickerComponent } from './datepicker.component';
+
+describe('DatepickerComponent', () => {
+  let component: DatepickerComponent;
+  let fixture: ComponentFixture<DatepickerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DatepickerComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DatepickerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/datepicker/datepicker.component.ts
+++ b/src/app/shared/components/datepicker/datepicker.component.ts
@@ -1,0 +1,29 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-datepicker',
+  templateUrl: './datepicker.component.html',
+  styleUrls: ['./datepicker.component.scss'],
+})
+export class DatepickerComponent {
+  @Input()
+  date: string | undefined;
+
+  @Output()
+  dateChange = new EventEmitter<string>();
+
+  dateModel: Date | undefined;
+
+  onDatePickerChange(newValue: Date) {
+    this.dateModel = newValue;
+
+    // See https://stackoverflow.com/a/34290167/369687
+    this.date = [
+      newValue.getFullYear(),
+      ('0' + (newValue.getMonth() + 1)).slice(-2),
+      ('0' + newValue.getDate()).slice(-2),
+    ].join('-');
+
+    this.dateChange.emit(this.date);
+  }
+}

--- a/src/app/shared/components/datepicker/datepicker.module.ts
+++ b/src/app/shared/components/datepicker/datepicker.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DatepickerComponent } from './datepicker.component';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { FormsModule } from '@angular/forms';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { TranslateModule } from '@ngx-translate/core';
+import { MatInputModule } from '@angular/material/input';
+
+@NgModule({
+  declarations: [DatepickerComponent],
+  exports: [DatepickerComponent],
+  imports: [CommonModule, FormsModule, MatFormFieldModule, MatInputModule, MatDatepickerModule, TranslateModule],
+})
+export class DatepickerModule {}

--- a/src/app/shared/components/datepicker/index.ts
+++ b/src/app/shared/components/datepicker/index.ts
@@ -1,0 +1,2 @@
+export * from './datepicker.module';
+export * from './datepicker.component';

--- a/src/app/shared/components/index.ts
+++ b/src/app/shared/components/index.ts
@@ -1,4 +1,5 @@
 export * from './cities-search/';
+export * from './datepicker/';
 export * from './more-info-link/more-info-link.component';
 export * from './type-of-help/type-of-help.component';
 export * from './category-navigation/category-navigation.component';

--- a/src/assets/styles/forms.scss
+++ b/src/assets/styles/forms.scss
@@ -7,5 +7,6 @@ form {
 
   mat-form-field {
     width: 100%;
+    font-size: 15px;
   }
 }

--- a/src/assets/styles/variables.scss
+++ b/src/assets/styles/variables.scss
@@ -1,6 +1,6 @@
 :root {
   --c-white: #fff;
-  --c-yellow: #fad500;
+  --c-yellow: #ffd500;
   --c-dark-yellow: #c7a900;
   --c-darkblue: #0c2c65;
   --c-blue: #1f52bd;


### PR DESCRIPTION
1. Fix the transport search list view, show destination in the result
2. Transport views & datepicker improvements/fixes

Apart from minor fixes like replacing some hard-coded texts in the transport
search view, this adds a new Datepicker component based on the Angular Material
one that wraps date handling to avoid the issue angular/components#7167. That
issue makes the Material Datepicker set dates one day earlier than the one
chosen by the user, at least in the Polish time zone. This change also uses that
new component in the transport views, both in find-help & give-help
variants.

Left to do is adding `ngModel` support to the Datepicker component instead of
binding to a custom prop name.
