### PR TITLE
POM-225 Various search view fixes/improvements

### DIFF
--- a/src/app/core/site-header/site-header.component.html
+++ b/src/app/core/site-header/site-header.component.html
@@ -2,12 +2,21 @@
   <nav class="navbar navbar-expand-lg">
     <div class="container">
       <div class="d-flex flex-row">
-        <img class="navbar-brand herb" [src]="'herb.png' | path: 'imagesPath'" alt="herb" />
-        <a href="https://www.gov.pl/web/premier" class="navbar-brand">
-          <img class="logo" [src]="'kprm.svg' | path: 'imagesPath'" alt="kancelaria prezesa rady ministrów" />
+        <a href="https://gov.pl">
+          <span class="visually-hidden">gov.pl</span>
+          <img class="navbar-brand herb" [src]="'herb.png' | path: 'imagesPath'" alt="herb" />
         </a>
-        <a href="https://pomagamukrainie.gov.pl/" class="navbar-brand">
-          <img class="logo" [src]="'pomagamyua.svg' | path: 'imagesPath'" alt="pomagamy ukrainie" />
+        <a href="https://www.gov.pl/web/premier" class="navbar-brand">
+          <span class="visually-hidden">{{ "CHANCELLERY_OF_PRIME_MINISTER" | translate }}</span>
+          <img
+            class="logo"
+            [src]="'kprm.svg' | path: 'imagesPath'"
+            [alt]="'CHANCELLERY_OF_PRIME_MINISTER' | translate"
+          />
+        </a>
+        <a href="/" class="navbar-brand">
+          <span class="visually-hidden">{{ "MAIN_PAGE" | translate }}</span>
+          <img class="logo" [src]="'pomagamyua.svg' | path: 'imagesPath'" [alt]="'MAIN_PAGE' | translate" />
         </a>
       </div>
 

--- a/src/app/core/translations/pl_PL.ts
+++ b/src/app/core/translations/pl_PL.ts
@@ -98,4 +98,5 @@ export default {
   YES: 'Tak',
   NO: 'Nie',
   PLACEHOLDER_LOCATION: 'Np. Rzeszów, podkarpackie',
+  CHANCELLERY_OF_PRIME_MINISTER: 'Kancelaria Prezesa Rady Ministrów',
 };

--- a/src/app/find-help/material-aid-search/material-aid-search.component.html
+++ b/src/app/find-help/material-aid-search/material-aid-search.component.html
@@ -15,7 +15,7 @@
     >
       <app-search-result-attribute
         *ngIf="result.category"
-        [text]="result.category"
+        [text]="result.category | translate"
         icon="interests_outline"
       ></app-search-result-attribute>
     </app-search-result>

--- a/src/app/find-help/material-aid-search/material-aid-search.module.ts
+++ b/src/app/find-help/material-aid-search/material-aid-search.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatNativeDateModule } from '@angular/material/core';
-import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
@@ -23,7 +22,6 @@ import { MaterialAidSearchFormComponent } from './material-aid-search-form/mater
     CommonModule,
     FormsModule,
     MatCardModule,
-    MatDatepickerModule,
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,

--- a/src/app/find-help/view-offer-accommodation/view-offer-accommodation.component.html
+++ b/src/app/find-help/view-offer-accommodation/view-offer-accommodation.component.html
@@ -39,7 +39,7 @@
       <p>{{ data.description }}</p>
     </div>
     <div class="disclaimer mb-3">{{ "CHANGE_LANG_SITE_DISCLAIMER" | translate }}</div>
-    <a href="#">&lt; {{ "BACK_TO_LIST" | translate }}</a>
+    <a [routerLink]="getListUrl()">&lt; {{ "BACK_TO_LIST" | translate }}</a>
   </mat-card>
   <div class="w-100 w-md-50">
     <app-reply-offer [helperPhoneNumber]="'123123213'" [helperFirstname]="data.userFirstName"></app-reply-offer>

--- a/src/app/find-help/view-offer-accommodation/view-offer-accommodation.component.ts
+++ b/src/app/find-help/view-offer-accommodation/view-offer-accommodation.component.ts
@@ -37,6 +37,10 @@ export class ViewOfferAccommodationComponent implements OnInit {
       .catch((e) => console.error(e));
   }
 
+  getListUrl(): string {
+    return this.router.url.replace(/\/[^/]+$/, '');
+  }
+
   getAccomodationOffer() {
     this.accommodationsResourceService.getAccommodations(this.offerId).subscribe((response) => {
       this.data = response;

--- a/src/app/find-help/view-offer-material-aid/view-offer-material-aid.component.html
+++ b/src/app/find-help/view-offer-material-aid/view-offer-material-aid.component.html
@@ -32,7 +32,7 @@
       <p>{{ data.description }}</p>
     </div>
     <div class="disclaimer mb-3">{{ "CHANGE_LANG_SITE_DISCLAIMER" | translate }}</div>
-    <a href="#">&lt; {{ "BACK_TO_LIST" | translate }}</a>
+    <a [routerLink]="getListUrl()">&lt; {{ "BACK_TO_LIST" | translate }}</a>
   </mat-card>
   <div class="w-100 w-md-50">
     <app-reply-offer [helperPhoneNumber]="'123123213'" [helperFirstname]="data.userFirstName"></app-reply-offer>

--- a/src/app/find-help/view-offer-material-aid/view-offer-material-aid.component.ts
+++ b/src/app/find-help/view-offer-material-aid/view-offer-material-aid.component.ts
@@ -31,6 +31,10 @@ export class ViewOfferMaterialAidComponent implements OnInit {
       .catch((e) => console.error(e));
   }
 
+  getListUrl(): string {
+    return this.router.url.replace(/\/[^/]+$/, '');
+  }
+
   getMaterialAidOffer() {
     this.materialAidResourceService.getMaterialAid(this.offerId).subscribe((response) => {
       this.data = response;

--- a/src/app/find-help/view-offer-transport/view-offer-transport.component.html
+++ b/src/app/find-help/view-offer-transport/view-offer-transport.component.html
@@ -47,7 +47,7 @@
       <p>{{ data.description }}</p>
     </div>
     <div class="disclaimer mb-3">{{ "CHANGE_LANG_SITE_DISCLAIMER" | translate }}</div>
-    <a href="#">&lt; {{ "BACK_TO_LIST" | translate }}</a>
+    <a [routerLink]="getListUrl()">&lt; {{ "BACK_TO_LIST" | translate }}</a>
   </mat-card>
   <div class="w-100 w-md-50">
     <app-reply-offer [helperPhoneNumber]="'123123213'" [helperFirstname]="data.userFirstName"></app-reply-offer>

--- a/src/app/find-help/view-offer-transport/view-offer-transport.component.ts
+++ b/src/app/find-help/view-offer-transport/view-offer-transport.component.ts
@@ -31,6 +31,10 @@ export class ViewOfferTransportComponent implements OnInit {
       .catch((e) => console.error(e));
   }
 
+  getListUrl(): string {
+    return this.router.url.replace(/\/[^/]+$/, '');
+  }
+
   getTransportOffer() {
     this.transportResourceService.getTransport(this.offerId).subscribe((response) => {
       this.data = response;

--- a/src/app/shared/components/category-navigation/category-navigation.component.html
+++ b/src/app/shared/components/category-navigation/category-navigation.component.html
@@ -1,16 +1,28 @@
 <nav class="navigation">
   <div class="categories">
     <ng-container *ngFor="let category of categories">
-      <app-type-of-help
-        [icon]="category.icon"
-        [name]="category.name"
-        [path]="['', outputPath, routingCategoryName[category.name]]"
-        [selected]="routingCategoryName[category.name] === activeRoute()"
-        [disabled]="category.disabled"
-        [redirectOnClick]="true"
-        [borderOnHover]="true"
+      <a
+        *ngIf="!category.disabled"
+        class="category-link"
+        [routerLink]="['/', outputPath, routingCategoryName[category.name]]"
       >
-      </app-type-of-help>
+        <app-type-of-help
+          [icon]="category.icon"
+          [name]="category.name"
+          [selected]="routingCategoryName[category.name] === activeRoute()"
+          [disabled]="category.disabled"
+        >
+        </app-type-of-help>
+      </a>
+      <div *ngIf="category.disabled">
+        <app-type-of-help
+          [icon]="category.icon"
+          [name]="category.name"
+          [selected]="routingCategoryName[category.name] === activeRoute()"
+          [disabled]="category.disabled"
+        >
+        </app-type-of-help>
+      </div>
     </ng-container>
   </div>
 </nav>

--- a/src/app/shared/components/category-navigation/category-navigation.component.scss
+++ b/src/app/shared/components/category-navigation/category-navigation.component.scss
@@ -19,4 +19,8 @@
       justify-content: center;
     }
   }
+
+  .category-link {
+    text-decoration: none;
+  }
 }

--- a/src/app/shared/components/category-navigation/category-navigation.component.ts
+++ b/src/app/shared/components/category-navigation/category-navigation.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, NgModule } from '@angular/core';
 import { Category, CategoryNameKey, CategoryRoutingName, CorePath } from '@app/shared/models';
 import { CommonModule } from '@angular/common';
-import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
 import { Router, RouterModule } from '@angular/router';
 import { TypeOfHelpComponentModule } from '@app/shared/components';
@@ -29,7 +29,7 @@ export class CategoryNavigationComponent {
   constructor(private router: Router) {}
 
   activeRoute(): string | undefined {
-    return this.router.url.split('/').pop();
+    return this.router.url.split('/')[2];
   }
 }
 

--- a/src/app/shared/components/cities-search/cities-search.component.html
+++ b/src/app/shared/components/cities-search/cities-search.component.html
@@ -3,7 +3,14 @@
     ><b>{{ label }}</b></label
   >
   <mat-form-field class="example-full-width" appearance="outline">
-    <input type="text" [placeholder]="placeholder" matInput [formControl]="formControl" [matAutocomplete]="auto" />
+    <input
+      type="text"
+      #autoCompleteInput
+      [placeholder]="placeholder"
+      matInput
+      [formControl]="formControl"
+      [matAutocomplete]="auto"
+    />
     <mat-autocomplete
       #auto="matAutocomplete"
       [displayWith]="displayOption"
@@ -13,5 +20,16 @@
         {{ option | displayLocationOption }}
       </mat-option>
     </mat-autocomplete>
+    <button
+      *ngIf="selectedOption"
+      type="button"
+      mat-button
+      matSuffix
+      mat-icon-button
+      aria-label="Clear"
+      (click)="clearValue()"
+    >
+      <mat-icon class="button-icon" fontSet="material-icons-outlined">close</mat-icon>
+    </button>
   </mat-form-field>
 </div>

--- a/src/app/shared/components/cities-search/cities-search.component.ts
+++ b/src/app/shared/components/cities-search/cities-search.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { debounceTime, distinctUntilChanged, filter, switchMap, tap } from 'rxjs';
 import { displayLocationOption, Location } from './display-location-option';
 import { CityLookupResourceService } from '@app/core/api';
+import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
 
 @Component({
   selector: 'app-cities-search',
@@ -21,6 +22,8 @@ export class CitiesSearchComponent implements OnInit, ControlValueAccessor {
 
   @Input() placeholder = '';
   @Input() label = '';
+
+  @ViewChild('autoCompleteInput', { read: MatAutocompleteTrigger }) autoComplete?: MatAutocompleteTrigger;
 
   options: Location[] = [];
   selectedOption?: Location;
@@ -49,7 +52,7 @@ export class CitiesSearchComponent implements OnInit, ControlValueAccessor {
     return displayLocationOption(location);
   }
 
-  onChange: (value: Location) => void = () => {};
+  onChange: (value: Location | undefined) => void = () => {};
 
   registerOnChange(fn: any): void {
     this.onChange = fn;
@@ -70,6 +73,19 @@ export class CitiesSearchComponent implements OnInit, ControlValueAccessor {
 
   writeValue(location: Location): void {
     this.selectedOption = location;
+  }
+
+  clearValue(): void {
+    this.selectedOption = undefined;
+    this.formControl.setValue('');
+    this.onChange(undefined);
+
+    // This doesn't work without a setTimeout.
+    // Unfortunately, with `setTimeout` there's sometimes
+    // small flickering. Better solutions welcome.
+    setTimeout(() => {
+      this.autoComplete?.closePanel();
+    });
   }
 
   onSelected(option: Location) {

--- a/src/app/shared/components/cities-search/cities-search.module.ts
+++ b/src/app/shared/components/cities-search/cities-search.module.ts
@@ -3,12 +3,14 @@ import { CommonModule } from '@angular/common';
 import { CitiesSearchComponent } from './cities-search.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { DisplayLocationOptionPipe } from './display-location-option';
 
 @NgModule({
   declarations: [CitiesSearchComponent, DisplayLocationOptionPipe],
-  imports: [CommonModule, ReactiveFormsModule, MatAutocompleteModule, MatInputModule],
+  imports: [CommonModule, ReactiveFormsModule, MatAutocompleteModule, MatButtonModule, MatIconModule, MatInputModule],
   exports: [CitiesSearchComponent],
 })
 export class CitiesSearchModule {}

--- a/src/app/shared/components/type-of-help/type-of-help.component.html
+++ b/src/app/shared/components/type-of-help/type-of-help.component.html
@@ -1,5 +1,4 @@
-<div *ngIf="unfoldOnSelect" class="top-unfold" [style.visibility]="topBottomVisibility"></div>
-<mat-card (click)="handleClick()" tabindex="0" role="button">
+<mat-card>
   <div class="icon-wrapper">
     <mat-icon class="material-icons-outlined">{{ icon }}</mat-icon>
   </div>
@@ -7,4 +6,3 @@
     <strong [innerHTML]="name | translate"></strong>
   </div>
 </mat-card>
-<div *ngIf="unfoldOnSelect" class="bottom-unfold" [style.visibility]="topBottomVisibility"></div>

--- a/src/app/shared/components/type-of-help/type-of-help.component.scss
+++ b/src/app/shared/components/type-of-help/type-of-help.component.scss
@@ -16,17 +16,21 @@ $unfold-height: 30px;
 :host {
   display: flex;
   flex-direction: column;
+
   cursor: pointer;
 
   mat-card {
+    flex: 1;
+
     display: flex;
     flex-direction: column;
+    justify-content: space-around;
+
     box-sizing: border-box;
     min-height: $card-height;
     max-height: $card-height;
     min-width: $card-width;
     max-width: $card-width;
-    padding-top: 0;
     border: $border-white;
     overflow: hidden;
     color: var(--c-darkblue);
@@ -74,18 +78,6 @@ $unfold-height: 30px;
       box-shadow: none;
       border: $border-default;
     }
-
-    &.unfold-on-select {
-      .icon-wrapper {
-        align-items: flex-start;
-      }
-
-      .mat-card:not([class*="mat-elevation-z"]) {
-        border-bottom: none;
-        border-top: none;
-        border-radius: 0;
-      }
-    }
   }
 
   &.disabled {
@@ -99,7 +91,7 @@ $unfold-height: 30px;
     }
   }
 
-  &.border-on-hover:not(.disabled) {
+  &:not(.disabled) {
     mat-card {
       &:hover,
       &:focus {

--- a/src/app/shared/components/type-of-help/type-of-help.component.ts
+++ b/src/app/shared/components/type-of-help/type-of-help.component.ts
@@ -1,15 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  HostBinding,
-  Input,
-  NgModule,
-  OnChanges,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ChangeDetectionStrategy, Component, EventEmitter, HostBinding, Input, NgModule, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCardModule } from '@angular/material/card';
@@ -26,7 +15,7 @@ enum Visibility {
   styleUrls: ['./type-of-help.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TypeOfHelpComponent implements OnChanges {
+export class TypeOfHelpComponent {
   /**
    * Material icon name.
    */
@@ -38,30 +27,9 @@ export class TypeOfHelpComponent implements OnChanges {
   @Input() name!: string;
 
   /**
-   * Path to redirect after click (relative to activated route). `RedirectOnClick` should be set to true to enable redirect.
-   * Path is represented as angular navigate commands (an array of URL fragments).
-   */
-  @Input() path?: any[];
-
-  /**
-   * Whether click should redirect to `path`.
-   */
-  @Input() redirectOnClick?: boolean;
-
-  /**
-   * Whether click should toggle selection status.
-   */
-  @Input() enableToggle?: boolean;
-
-  /**
    * Whether component is selected.
    */
   @Input() @HostBinding('class.selected') selected?: boolean;
-
-  /**
-   * Whether component should unfold top and bottom after being selected.
-   */
-  @Input() @HostBinding('class.unfold-on-select') unfoldOnSelect?: boolean;
 
   /**
    * Whether component should be disabled. Disabled component does not emit click event or redirect to `path`.
@@ -69,79 +37,11 @@ export class TypeOfHelpComponent implements OnChanges {
   @Input() @HostBinding('class.disabled') disabled?: boolean;
 
   /**
-   * Whether component should display border on hover.
-   */
-  @Input() @HostBinding('class.border-on-hover') borderOnHover?: boolean;
-
-  /**
    * Emitter for element click. Emits selection status.
    * true - selected
    * false - not selected
    */
   @Output() cardClicked: EventEmitter<boolean> = new EventEmitter<boolean>();
-
-  /**
-   * Visibility of top and bottom unfolding elements.
-   */
-  topBottomVisibility: string = Visibility.HIDDEN;
-
-  constructor(private router: Router, private activatedRoute: ActivatedRoute) {}
-
-  ngOnChanges(changes: SimpleChanges): void {
-    this.checkTopBottomVisibility();
-  }
-
-  /**
-   * Handle click.
-   */
-  handleClick() {
-    if (!this.disabled) {
-      if (this.redirectOnClick) {
-        this.redirect();
-      } else {
-        if (this.enableToggle || (!this.enableToggle && !this.selected)) {
-          this.toggleSelection();
-          this.checkTopBottomVisibility();
-        }
-        this.emitSelectionStatus();
-      }
-    }
-  }
-
-  /**
-   * Emits card clicked event with `selected` status.
-   * @private
-   */
-  private emitSelectionStatus() {
-    this.cardClicked.emit(this.selected);
-  }
-
-  /**
-   * Redirects to `path` if value of `path` is not empty.
-   * @private
-   */
-  private redirect() {
-    if (this.path) {
-      this.router.navigate(this.path || [], { relativeTo: this.activatedRoute });
-    }
-  }
-
-  /**
-   * Checks visibility of top and bottom unfolding part of component.
-   * @private
-   */
-  private checkTopBottomVisibility() {
-    this.topBottomVisibility =
-      !this.disabled && this.selected && this.unfoldOnSelect ? Visibility.VISIBLE : Visibility.HIDDEN;
-  }
-
-  /**
-   * Toggle selection.
-   * @private
-   */
-  private toggleSelection() {
-    this.selected = !this.selected;
-  }
 }
 
 @NgModule({

--- a/src/assets/styles/utilities.scss
+++ b/src/assets/styles/utilities.scss
@@ -47,3 +47,16 @@
     display: none;
   }
 }
+
+// Source: https://github.com/twbs/bootstrap/blob/v5.1.3/scss/mixins/_visually-hidden.scss
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important; // Fix for https://github.com/twbs/bootstrap/issues/25686
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}


### PR DESCRIPTION
## List of changes

Commits are divided more or less per acceptance criteria from https://jira.sysopspolska.pl/browse/POM-225.

#### 1\. Support clearing the cities search input value

This adds the "x" button to the autocomplete input which clears the value,
allowing again to search among all annoucements.

#### 2\. KA3: remove unused MatDatepickerModule from material-aid-search

#### 3\. KA1: link Polish coat of arms to the main page

Also, improve accessibility of those links

#### 4\. KA4: Preserve category highlight when opening an offer

#### 5\. Makes categories real links, remove lots of dead code

#### 6\. KA5: Fix "back to list" links in offers

Note: this goes back to the proper view but in its initial, empty state.
Ideally, we should get back to the exact same list we were at when clicking
on the offer. Perhaps views should be modified so that the offer displays on top
of the search view (if you go directly via URL, it would just be empty)? That
way, navigating to the list view could preserve what's already there on the
list.

#### 7\. Translate categories in material aid search results

## Other remarks

The commit that made categories real links, improving accessibility, also removed lots of dead code from the `type-of-help` component. I'm not sure what was the purpose of all this, @Vodzoo authored it originally in #22, maybe you could double-check this PR?