### PR TITLE
Fix the generate-api.sh script

### DIFF
--- a/generate-api.sh
+++ b/generate-api.sh
@@ -3,7 +3,7 @@ cd "$(dirname "$0")"
 rm -rf src/app/core/api
 set -eu
 npx openapi-generator-cli generate \
-   -i http://localhost:8080/v3/api-docs \
+   -i http://localhost:8080/ogloszenia/v3/api-docs \
    -g typescript-angular \
    -o src/app/core/api
 rm -f src/api/{README.md,git_push.sh}


### PR DESCRIPTION
It wasn't properly updated after the API prefix of "/ogloszenia" was set up.

Ref coi-gov-pl/pomocua-ogloszenia#83
Ref #95