### PR TITLE
POM-296 Create properly typed versions of offers

### DIFF
--- a/mock/data/accommodation.ts
+++ b/mock/data/accommodation.ts
@@ -1,4 +1,5 @@
-import { AccommodationOffer, AccommodationOfferDefinitionDTO, OffersAccommodationOffer } from '@app/core/api';
+import { AccommodationOfferDefinitionDTO } from '@app/core/api';
+import { AccommodationOffer, OffersAccommodationOffer } from '@app/shared/models';
 
 export const accommodationOffer = (body: AccommodationOfferDefinitionDTO): AccommodationOffer => {
   return {
@@ -6,6 +7,7 @@ export const accommodationOffer = (body: AccommodationOfferDefinitionDTO): Accom
     id: 1,
     userFirstName: 'example',
     modifiedDate: new Date().toISOString(),
+    type: 'accommodation',
   };
 };
 
@@ -23,6 +25,7 @@ export const accommodationsList: OffersAccommodationOffer = {
       lengthOfStay: 'MONTH_2',
       hostLanguage: ['PL', 'UA'],
       phoneNumber: '48123456789',
+      type: 'accommodation',
     },
     {
       id: 3,
@@ -36,6 +39,7 @@ export const accommodationsList: OffersAccommodationOffer = {
       lengthOfStay: 'LONGER',
       hostLanguage: ['PL', 'UA'],
       phoneNumber: '48456789123',
+      type: 'accommodation',
     },
     {
       id: 13,
@@ -49,6 +53,7 @@ export const accommodationsList: OffersAccommodationOffer = {
       lengthOfStay: 'MONTH_2',
       hostLanguage: ['PL', 'UA'],
       phoneNumber: '48789123456',
+      type: 'accommodation',
     },
     {
       id: 15,
@@ -62,6 +67,7 @@ export const accommodationsList: OffersAccommodationOffer = {
       lengthOfStay: 'LONGER',
       hostLanguage: ['PL', 'UA'],
       phoneNumber: '48891234567',
+      type: 'accommodation',
     },
   ],
   totalElements: 4,

--- a/mock/data/material-aid.ts
+++ b/mock/data/material-aid.ts
@@ -1,4 +1,5 @@
-import { MaterialAidOffer, MaterialAidOfferDefinitionDTO, OffersMaterialAidOffer } from '@app/core/api';
+import { MaterialAidOfferDefinitionDTO } from '@app/core/api';
+import { MaterialAidOffer, OffersMaterialAidOffer } from '@app/shared/models';
 
 export const materialAidOffer = (body: MaterialAidOfferDefinitionDTO): MaterialAidOffer => {
   return {
@@ -6,6 +7,7 @@ export const materialAidOffer = (body: MaterialAidOfferDefinitionDTO): MaterialA
     id: 1,
     userFirstName: 'example',
     modifiedDate: new Date().toISOString(),
+    type: 'materialAid',
   };
 };
 
@@ -20,6 +22,7 @@ export const materialAidList: OffersMaterialAidOffer = {
       category: 'HOUSEHOLD_GOODS',
       location: { region: 'Pomorskie', city: 'Gdańsk' },
       phoneNumber: '48123456789',
+      type: 'materialAid',
     },
     {
       id: 7,
@@ -30,6 +33,7 @@ export const materialAidList: OffersMaterialAidOffer = {
       category: 'FOR_CHILDREN',
       location: { region: 'Mazowieckie', city: 'Warszawa' },
       phoneNumber: '48456789123',
+      type: 'materialAid',
     },
     {
       id: 17,
@@ -40,6 +44,7 @@ export const materialAidList: OffersMaterialAidOffer = {
       category: 'HOUSEHOLD_GOODS',
       location: { region: 'Pomorskie', city: 'Gdańsk' },
       phoneNumber: '48789123456',
+      type: 'materialAid',
     },
     {
       id: 19,
@@ -50,6 +55,7 @@ export const materialAidList: OffersMaterialAidOffer = {
       category: 'FOR_CHILDREN',
       location: { region: 'Mazowieckie', city: 'Warszawa' },
       phoneNumber: '48891234567',
+      type: 'materialAid',
     },
   ],
   totalElements: 4,

--- a/mock/data/transport.ts
+++ b/mock/data/transport.ts
@@ -1,4 +1,5 @@
-import { OffersTransportOffer, TransportOffer, TransportOfferDefinitionDTO } from '@app/core/api';
+import { TransportOfferDefinitionDTO } from '@app/core/api';
+import { OffersTransportOffer, TransportOffer } from '@app/shared/models';
 
 export const transportOffer = (body: TransportOfferDefinitionDTO): TransportOffer => {
   return {
@@ -6,6 +7,7 @@ export const transportOffer = (body: TransportOfferDefinitionDTO): TransportOffe
     id: 1,
     userFirstName: 'example',
     modifiedDate: new Date().toISOString(),
+    type: 'transport',
   };
 };
 
@@ -23,6 +25,7 @@ export const transportList: OffersTransportOffer = {
       capacity: 11,
       transportDate: '2022-03-14',
       phoneNumber: '48123456789',
+      type: 'transport',
     },
     {
       id: 11,
@@ -36,6 +39,7 @@ export const transportList: OffersTransportOffer = {
       capacity: 10,
       transportDate: '2022-03-14',
       phoneNumber: '48456789123',
+      type: 'transport',
     },
     {
       id: 21,
@@ -49,6 +53,7 @@ export const transportList: OffersTransportOffer = {
       capacity: 11,
       transportDate: '2022-03-16',
       phoneNumber: '48789123456',
+      type: 'transport',
     },
     {
       id: 23,
@@ -62,6 +67,7 @@ export const transportList: OffersTransportOffer = {
       capacity: 10,
       transportDate: '2022-03-16',
       phoneNumber: '48891234567',
+      type: 'transport',
     },
   ],
   totalElements: 4,

--- a/mock/data/user.ts
+++ b/mock/data/user.ts
@@ -1,4 +1,5 @@
-import { OffersBaseOffer, UserInfo } from '@app/core/api';
+import { UserInfo } from '@app/core/api';
+import { OffersBaseOffer } from '@app/shared/models';
 
 export const loggedUserInfo: UserInfo = { email: 'john@email.invalid', firstName: 'John', phoneNumber: undefined };
 
@@ -19,6 +20,7 @@ export const userOffers: OffersBaseOffer = {
       lengthOfStay: 'MONTH_2',
       hostLanguage: ['PL', 'UA'],
       phoneNumber: '48123456789',
+      type: 'accommodation',
     },
     {
       id: 19,
@@ -32,6 +34,7 @@ export const userOffers: OffersBaseOffer = {
         city: 'Warszawa',
       },
       phoneNumber: '48456789123',
+      type: 'materialAid',
     },
     {
       id: 23,
@@ -51,6 +54,7 @@ export const userOffers: OffersBaseOffer = {
       capacity: 10,
       transportDate: '2022-03-16',
       phoneNumber: '48789123456',
+      type: 'transport',
     },
   ],
   totalElements: 3,

--- a/src/app/my-account/confirm-remove-ad/confirm-remove-ad.component.html
+++ b/src/app/my-account/confirm-remove-ad/confirm-remove-ad.component.html
@@ -5,38 +5,52 @@
   <div class="title">{{ "CONFIRM_REMOVE_AD" | translate }}</div>
 
   <app-search-result
-    [location]="$any(currentAnnouncement).location"
-    [origin]="$any(currentAnnouncement).origin"
-    [destination]="$any(currentAnnouncement).destination"
+    *ngIf="currentAnnouncement.type === 'accommodation'"
+    [location]="currentAnnouncement.location"
     [title]="currentAnnouncement.title"
     [description]="currentAnnouncement.description"
     [posted]="currentAnnouncement.modifiedDate"
     class="item-wrapper"
   >
     <app-search-result-attribute
-      *ngIf="$any(currentAnnouncement).guests"
-      [text]="('NUMBER_OF_PEOPLE' | translate) + ': ' + $any(currentAnnouncement).guests"
+      [text]="('NUMBER_OF_PEOPLE' | translate) + ': ' + currentAnnouncement.guests"
       icon="person"
     ></app-search-result-attribute>
     <app-search-result-attribute
-      *ngIf="$any(currentAnnouncement).hostLanguage"
-      [text]="$any(currentAnnouncement).hostLanguage.join(', ')"
+      [text]="currentAnnouncement.hostLanguage.join(', ')"
       icon="translate"
     ></app-search-result-attribute>
+  </app-search-result>
+
+  <app-search-result
+    *ngIf="currentAnnouncement.type === 'materialAid'"
+    [location]="currentAnnouncement.location"
+    [title]="currentAnnouncement.title"
+    [description]="currentAnnouncement.description"
+    [posted]="currentAnnouncement.modifiedDate"
+    class="item-wrapper"
+  >
     <app-search-result-attribute
-      *ngIf="$any(currentAnnouncement).category"
-      [text]="$any(currentAnnouncement).category | translate"
+      [text]="currentAnnouncement.category | translate"
       icon="interests_outline"
     ></app-search-result-attribute>
+  </app-search-result>
 
+  <app-search-result
+    *ngIf="currentAnnouncement.type === 'transport'"
+    [origin]="currentAnnouncement.origin"
+    [destination]="currentAnnouncement.destination"
+    [title]="currentAnnouncement.title"
+    [description]="currentAnnouncement.description"
+    [posted]="currentAnnouncement.modifiedDate"
+    class="item-wrapper"
+  >
     <app-search-result-attribute
-      *ngIf="$any(currentAnnouncement).transportDate"
-      [text]="$any(currentAnnouncement).transportDate"
+      [text]="currentAnnouncement.transportDate"
       icon="date_range"
     ></app-search-result-attribute>
     <app-search-result-attribute
-      *ngIf="$any(currentAnnouncement).capacity"
-      [text]="('NUMBER_OF_PEOPLE' | translate) + ': ' + $any(currentAnnouncement).capacity"
+      [text]="('NUMBER_OF_PEOPLE' | translate) + ': ' + currentAnnouncement.capacity"
       icon="person"
     ></app-search-result-attribute>
   </app-search-result>

--- a/src/app/my-account/confirm-remove-ad/confirm-remove-ad.component.ts
+++ b/src/app/my-account/confirm-remove-ad/confirm-remove-ad.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { AccommodationOffer, MaterialAidOffer, OffersBaseOffer, TransportOffer } from '@app/core/api';
+import { AccommodationOffer, MaterialAidOffer, TransportOffer } from '@app/shared/models';
 
 @Component({
   selector: 'app-confirm-remove-ad',

--- a/src/app/my-account/my-account/my-account.component.html
+++ b/src/app/my-account/my-account/my-account.component.html
@@ -18,50 +18,87 @@
   <section *ngIf="myAnnouncements?.content?.length">
     <p class="text">{{ "YOUR_ANNOUNCEMENT" | translate }}</p>
     <div class="announcements-wrapper">
-      <app-search-result
-        *ngFor="let announcement of myAnnouncements.content"
-        [location]="$any(announcement).location"
-        [origin]="$any(announcement).origin"
-        [destination]="$any(announcement).destination"
-        [title]="announcement.title"
-        [description]="announcement.description"
-        [posted]="announcement.modifiedDate"
-      >
-        <app-search-result-attribute
-          *ngIf="$any(announcement).guests"
-          [text]="('NUMBER_OF_PEOPLE' | translate) + ': ' + $any(announcement).guests"
-          icon="person"
-        ></app-search-result-attribute>
-        <app-search-result-attribute
-          *ngIf="$any(announcement).hostLanguage"
-          [text]="$any(announcement).hostLanguage.join(', ')"
-          icon="translate"
-        ></app-search-result-attribute>
-        <app-search-result-attribute
-          *ngIf="$any(announcement).category"
-          [text]="$any(announcement).category | translate"
-          icon="interests_outline"
-        ></app-search-result-attribute>
+      <ng-container *ngFor="let announcement of myAnnouncements.content">
+        <app-search-result
+          *ngIf="announcement.type === 'accommodation'"
+          [location]="announcement.location"
+          [title]="announcement.title"
+          [description]="announcement.description"
+          [posted]="announcement.modifiedDate"
+        >
+          <app-search-result-attribute
+            *ngIf="announcement.guests"
+            [text]="('NUMBER_OF_PEOPLE' | translate) + ': ' + announcement.guests"
+            icon="person"
+          ></app-search-result-attribute>
+          <app-search-result-attribute
+            *ngIf="announcement.hostLanguage"
+            [text]="announcement.hostLanguage.join(', ')"
+            icon="translate"
+          ></app-search-result-attribute>
 
-        <app-search-result-attribute
-          *ngIf="$any(announcement).transportDate"
-          [text]="$any(announcement).transportDate"
-          icon="date_range"
-        ></app-search-result-attribute>
-        <app-search-result-attribute
-          *ngIf="$any(announcement).capacity"
-          [text]="('NUMBER_OF_PEOPLE' | translate) + ': ' + $any(announcement).capacity"
-          icon="person"
-        ></app-search-result-attribute>
-        <div class="pt-2 pt-sm-0 ps-sm-2" buttons>
-          <button type="button" class="btn btn-secondary mb-2" (click)="editAnnouncement(announcement)">
-            {{ "EDIT_ANNOUNCEMENT" | translate }}
-          </button>
-          <button type="button" class="btn btn-link btn-sm" (click)="removeAnnouncement(announcement)">
-            {{ "REMOVE_ANNOUNCEMENT" | translate }}
-          </button>
-        </div>
-      </app-search-result>
+          <div class="pt-2 pt-sm-0 ps-sm-2" buttons>
+            <button type="button" class="btn btn-secondary mb-2" (click)="editAnnouncement(announcement)">
+              {{ "EDIT_ANNOUNCEMENT" | translate }}
+            </button>
+            <button type="button" class="btn btn-link btn-sm" (click)="removeAnnouncement(announcement)">
+              {{ "REMOVE_ANNOUNCEMENT" | translate }}
+            </button>
+          </div>
+        </app-search-result>
+
+        <app-search-result
+          *ngIf="announcement.type === 'materialAid'"
+          [location]="announcement.location"
+          [title]="announcement.title"
+          [description]="announcement.description"
+          [posted]="announcement.modifiedDate"
+        >
+          <app-search-result-attribute
+            *ngIf="announcement.category"
+            [text]="announcement.category | translate"
+            icon="interests_outline"
+          ></app-search-result-attribute>
+
+          <div class="pt-2 pt-sm-0 ps-sm-2" buttons>
+            <button type="button" class="btn btn-secondary mb-2" (click)="editAnnouncement(announcement)">
+              {{ "EDIT_ANNOUNCEMENT" | translate }}
+            </button>
+            <button type="button" class="btn btn-link btn-sm" (click)="removeAnnouncement(announcement)">
+              {{ "REMOVE_ANNOUNCEMENT" | translate }}
+            </button>
+          </div>
+        </app-search-result>
+
+        <app-search-result
+          *ngIf="announcement.type === 'transport'"
+          [origin]="announcement.origin"
+          [destination]="announcement.destination"
+          [title]="announcement.title"
+          [description]="announcement.description"
+          [posted]="announcement.modifiedDate"
+        >
+          <app-search-result-attribute
+            *ngIf="announcement.transportDate"
+            [text]="announcement.transportDate"
+            icon="date_range"
+          ></app-search-result-attribute>
+          <app-search-result-attribute
+            *ngIf="announcement.capacity"
+            [text]="('NUMBER_OF_PEOPLE' | translate) + ': ' + announcement.capacity"
+            icon="person"
+          ></app-search-result-attribute>
+
+          <div class="pt-2 pt-sm-0 ps-sm-2" buttons>
+            <button type="button" class="btn btn-secondary mb-2" (click)="editAnnouncement(announcement)">
+              {{ "EDIT_ANNOUNCEMENT" | translate }}
+            </button>
+            <button type="button" class="btn btn-link btn-sm" (click)="removeAnnouncement(announcement)">
+              {{ "REMOVE_ANNOUNCEMENT" | translate }}
+            </button>
+          </div>
+        </app-search-result>
+      </ng-container>
       <!-- TODO: add paginator / global component-->
     </div>
   </section>

--- a/src/app/my-account/my-account/my-account.component.ts
+++ b/src/app/my-account/my-account/my-account.component.ts
@@ -1,16 +1,15 @@
 import { Component, OnInit } from '@angular/core';
+import { MyOffersResourceService, Pageable, UserInfo } from '@app/core/api';
+import { Observable, take } from 'rxjs';
+import { Router } from '@angular/router';
 import {
+  CategoryRoutingName,
+  CorePath,
   AccommodationOffer,
   MaterialAidOffer,
-  MyOffersResourceService,
   OffersBaseOffer,
-  Pageable,
   TransportOffer,
-  UserInfo,
-} from '@app/core/api';
-import { take } from 'rxjs';
-import { Router } from '@angular/router';
-import { CategoryRoutingName, CorePath } from '@app/shared/models';
+} from '@app/shared/models';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ConfirmRemoveAdComponent } from '../confirm-remove-ad/confirm-remove-ad.component';
 
@@ -26,7 +25,7 @@ export class MyAccountComponent implements OnInit {
   constructor(private router: Router, private myOffersResource: MyOffersResourceService, private dialog: MatDialog) {}
 
   public ngOnInit() {
-    this.myOffersResource.listMyOffers(this.pageRequest).subscribe((results) => {
+    (this.myOffersResource.listMyOffers(this.pageRequest) as Observable<OffersBaseOffer>).subscribe((results) => {
       this.myAnnouncements = results;
     });
   }

--- a/src/app/shared/models/api-workarounds.ts
+++ b/src/app/shared/models/api-workarounds.ts
@@ -1,0 +1,43 @@
+// Temporary types needed before backend fixes itself
+// Ideally, link each workaround to a JIRA after fixing which
+// it can be removed.
+
+import {
+  AccommodationOffer as AccommodationOfferFromAPI,
+  MaterialAidOffer as MaterialAidOfferFromAPI,
+  OffersAccommodationOffer as OffersAccommodationOfferFromAPI,
+  OffersMaterialAidOffer as OffersMaterialAidOfferFromAPI,
+  OffersTransportOffer as OffersTransportOfferFromAPI,
+  OffersBaseOffer as OffersBaseOfferFromAPI,
+  TransportOffer as TransportOfferFromAPI,
+} from '@app/core/api';
+
+// Remove once https://jira.sysopspolska.pl/browse/POM-299 is fixed.
+export type AccommodationOffer = Omit<AccommodationOfferFromAPI, 'type'> & {
+  type: 'accommodation';
+};
+// Remove once https://jira.sysopspolska.pl/browse/POM-299 is fixed.
+export type MaterialAidOffer = Omit<MaterialAidOfferFromAPI, 'type'> & {
+  type: 'materialAid';
+};
+// Remove once https://jira.sysopspolska.pl/browse/POM-299 is fixed.
+export type TransportOffer = Omit<TransportOfferFromAPI, 'type'> & {
+  type: 'transport';
+};
+
+// Remove once https://jira.sysopspolska.pl/browse/POM-299 is fixed.
+export type OffersAccommodationOffer = Omit<OffersAccommodationOfferFromAPI, 'content'> & {
+  content?: Array<AccommodationOffer>;
+};
+// Remove once https://jira.sysopspolska.pl/browse/POM-299 is fixed.
+export type OffersMaterialAidOffer = Omit<OffersMaterialAidOfferFromAPI, 'content'> & {
+  content?: Array<MaterialAidOffer>;
+};
+// Remove once https://jira.sysopspolska.pl/browse/POM-299 is fixed.
+export type OffersTransportOffer = Omit<OffersTransportOfferFromAPI, 'content'> & {
+  content?: Array<TransportOffer>;
+};
+// Remove once https://jira.sysopspolska.pl/browse/POM-299 is fixed.
+export type OffersBaseOffer = Omit<OffersBaseOfferFromAPI, 'content'> & {
+  content?: Array<AccommodationOffer | MaterialAidOffer | TransportOffer>;
+};

--- a/src/app/shared/models/index.ts
+++ b/src/app/shared/models/index.ts
@@ -1,3 +1,4 @@
+export * from './api-workarounds';
 export * from './breadcrumb-labels.model';
 export * from './breadcrumb.model';
 export * from './category-name-key.model';


### PR DESCRIPTION
This creates tweaks of some offer types to include a properly typed `type` field
that can be used for TypeScript discriminated union types and lets us avoid
using `$any` in templates.

The workarounds can be removed once https://jira.sysopspolska.pl/browse/POM-299
gets fixed on the backend side and the API is regenerated.

Reviewing with whitespace-only changes ignored is advised as lots of lines changed indentation levels:
https://github.com/coi-gov-pl/gui-web-pomogamukrainie-forum/pull/116/files?w=1