### PR TITLE
Drop a deprecated `--prod` flag to `ng build`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY . .
 RUN npm cache clean --force
 RUN npm ci
-RUN npx ng build --prod --base-href=/ogloszenia/
+RUN npx ng build --base-href=/ogloszenia/
 
 FROM nginx:1.21.6 AS ngi
 


### PR DESCRIPTION
From the message it prints:
> Option "--prod" is deprecated: No need to use this option as this builder
> defaults to configuration "production".