### PR TITLE
POM-343, POM-342 fix breadcrumbs building and "back to list" button from My Account context.

### DIFF
--- a/src/app/about-app/about-app-routing.module.ts
+++ b/src/app/about-app/about-app-routing.module.ts
@@ -6,6 +6,9 @@ const routes: Routes = [
   {
     path: '',
     component: AboutAppComponent,
+    data: {
+      title: null,
+    },
   },
 ];
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -9,6 +9,9 @@ const routes: Routes = [
   {
     path: '',
     loadChildren: () => import('./welcome/welcome.module').then((m) => m.WelcomeModule),
+    data: {
+      title: null,
+    },
   },
   {
     path: CorePath.Find,

--- a/src/app/core/translations/pl_PL.ts
+++ b/src/app/core/translations/pl_PL.ts
@@ -184,4 +184,5 @@ export default {
   PAGE_NOT_FOUND: 'Brak strony',
   PAGE_NOT_FOUND_LONG: 'Nie znaleziono takiej strony.',
   PAGE_NOT_FOUND_NEXT_ACTION: 'Wyszukaj ogłoszenie',
+  AD: 'Ogłoszenie',
 };

--- a/src/app/find-help/accommodation-search/accomodation-search.routing.module.ts
+++ b/src/app/find-help/accommodation-search/accomodation-search.routing.module.ts
@@ -1,21 +1,30 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { NotFoundComponent } from '@app/shared/components/not-found/not-found.component';
-import { CategoryRoutingName } from '@app/shared/models';
+import { BreadcrumbLabels, CategoryRoutingName } from '@app/shared/models';
 import { AccommodationSearchComponent } from './accommodation-search.component';
 
 const routes: Routes = [
   {
     path: '',
+    data: {
+      title: null,
+    },
     children: [
       {
         path: '',
         component: AccommodationSearchComponent,
+        data: {
+          title: null,
+        },
       },
       {
         path: CategoryRoutingName.NOT_FOUND,
         component: NotFoundComponent,
         loadChildren: () => import('../../shared/components/not-found/not-found.module').then((m) => m.NotFoundModule),
+        data: {
+          title: null,
+        },
       },
       {
         path: ':id',
@@ -23,6 +32,9 @@ const routes: Routes = [
           import('../view-offer-accommodation/view-offer-accommodation.module').then(
             (m) => m.ViewOfferAccommodationModule
           ),
+        data: {
+          title: BreadcrumbLabels.AD,
+        },
       },
     ],
   },

--- a/src/app/find-help/find-help-routing.module.ts
+++ b/src/app/find-help/find-help-routing.module.ts
@@ -8,11 +8,17 @@ const routes: Routes = [
   {
     path: '',
     component: FindHelpComponent,
+    data: {
+      title: null,
+    },
     children: [
       {
         path: '',
         redirectTo: CategoryRoutingName.ACCOMMODATION,
         pathMatch: 'full',
+        data: {
+          title: null,
+        },
       },
       {
         path: CategoryRoutingName.ACCOMMODATION,

--- a/src/app/find-help/material-aid-search/material-aid-search.routing.module.ts
+++ b/src/app/find-help/material-aid-search/material-aid-search.routing.module.ts
@@ -1,26 +1,38 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { NotFoundComponent } from '@app/shared/components/not-found/not-found.component';
-import { CategoryRoutingName } from '@app/shared/models';
+import { BreadcrumbLabels, CategoryRoutingName } from '@app/shared/models';
 import { MaterialAidSearchComponent } from './material-aid-search.component';
 
 const routes: Routes = [
   {
     path: '',
+    data: {
+      title: null,
+    },
     children: [
       {
         path: '',
         component: MaterialAidSearchComponent,
+        data: {
+          title: null,
+        },
       },
       {
         path: CategoryRoutingName.NOT_FOUND,
         component: NotFoundComponent,
         loadChildren: () => import('../../shared/components/not-found/not-found.module').then((m) => m.NotFoundModule),
+        data: {
+          title: null,
+        },
       },
       {
         path: ':id',
         loadChildren: () =>
           import('../view-offer-material-aid/view-offer-material-aid.module').then((m) => m.ViewOfferMaterialAidModule),
+        data: {
+          title: BreadcrumbLabels.AD,
+        },
       },
     ],
   },

--- a/src/app/find-help/reply-offer/reply-offer.routing.module.ts
+++ b/src/app/find-help/reply-offer/reply-offer.routing.module.ts
@@ -6,6 +6,7 @@ const routes: Routes = [
   {
     path: '',
     component: ReplyOfferComponent,
+    data: { title: null },
   },
 ];
 

--- a/src/app/find-help/search-result/search-result.component.ts
+++ b/src/app/find-help/search-result/search-result.component.ts
@@ -25,6 +25,9 @@ export class SearchResultComponent implements OnChanges {
   posted?: Date | string | undefined;
   @Input()
   origin?: Location;
+  @Input()
+  routePathPrefix: string[] = [CorePath.Find];
+
   postedDate: Date | undefined;
   CategoryRoutingName = CategoryRoutingName;
 
@@ -32,7 +35,7 @@ export class SearchResultComponent implements OnChanges {
 
   onViewOffer() {
     if (this.offerId) {
-      this.router.navigate([CorePath.Find, this.category, this.offerId]);
+      this.router.navigate([...this.routePathPrefix, this.category, this.offerId]);
     }
   }
 

--- a/src/app/find-help/transport-search/transport-search.routing.module.ts
+++ b/src/app/find-help/transport-search/transport-search.routing.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { NotFoundComponent } from '@app/shared/components/not-found/not-found.component';
-import { CategoryRoutingName } from '@app/shared/models';
+import { BreadcrumbLabels, CategoryRoutingName } from '@app/shared/models';
 import { TransportSearchComponent } from './transport-search.component';
 
 const routes: Routes = [
@@ -11,18 +11,22 @@ const routes: Routes = [
       {
         path: '',
         component: TransportSearchComponent,
+        data: { title: null },
       },
     ],
+    data: { title: null },
   },
   {
     path: CategoryRoutingName.NOT_FOUND,
     component: NotFoundComponent,
     loadChildren: () => import('../../shared/components/not-found/not-found.module').then((m) => m.NotFoundModule),
+    data: { title: null },
   },
   {
     path: ':id',
     loadChildren: () =>
       import('../view-offer-transport/view-offer-transport.module').then((m) => m.ViewOfferTransportModule),
+    data: { title: BreadcrumbLabels.AD },
   },
 ];
 

--- a/src/app/find-help/view-offer-accommodation/view-offer-accommodation.component.html
+++ b/src/app/find-help/view-offer-accommodation/view-offer-accommodation.component.html
@@ -40,7 +40,7 @@
       <p>{{ data.description }}</p>
     </div>
     <div class="disclaimer mb-3">{{ "CHANGE_LANG_SITE_DISCLAIMER" | translate }}</div>
-    <a (click)="navigateBack()">&lt; {{ "BACK_TO_LIST" | translate }}</a>
+    <app-back-to-list [categoryRouteName]="categoryRouteName"></app-back-to-list>
   </mat-card>
   <div class="w-100 w-md-50">
     <app-reply-offer

--- a/src/app/find-help/view-offer-accommodation/view-offer-accommodation.component.ts
+++ b/src/app/find-help/view-offer-accommodation/view-offer-accommodation.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { AccommodationOffer, AccommodationsResourceService } from '@app/core/api';
 import { CategoryRoutingName, CorePath } from '@app/shared/models';
 import { defaults } from '@app/shared/utils';
-import { StoreUrlService } from '@app/core/store-url';
 import { UrlHelperService } from '@app/core/url';
 
 @Component({
@@ -24,7 +23,6 @@ export class ViewOfferAccommodationComponent implements OnInit {
     private route: ActivatedRoute,
     private accommodationsResourceService: AccommodationsResourceService,
     private router: Router,
-    private storeUrlService: StoreUrlService,
     private urlHelperService: UrlHelperService
   ) {}
 
@@ -38,12 +36,6 @@ export class ViewOfferAccommodationComponent implements OnInit {
       .writeText(this.urlHelperService.basePath(true) + this.router.url.substring(1))
       .then()
       .catch((e) => console.error(e));
-  }
-
-  navigateBack(): void {
-    this.router.navigate([this.router.url.replace(/\/[^/]+$/, '')], {
-      queryParams: this.storeUrlService.getParams(this.categoryRouteName),
-    });
   }
 
   getAccomodationOffer() {

--- a/src/app/find-help/view-offer-accommodation/view-offer-accommodation.module.ts
+++ b/src/app/find-help/view-offer-accommodation/view-offer-accommodation.module.ts
@@ -11,6 +11,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { ViewOfferAccommodationComponent } from './view-offer-accommodation.component';
 import { ReplyOfferModule } from '../reply-offer/reply-offer.module';
 import { ViewOfferAccomodationModule } from './view-offer-accommodation.routing.module';
+import { BackToListModule } from '@app/shared/components/back-to-list/back-to-list.module';
 
 @NgModule({
   declarations: [ViewOfferAccommodationComponent],
@@ -26,6 +27,7 @@ import { ViewOfferAccomodationModule } from './view-offer-accommodation.routing.
     MatIconModule,
     ReplyOfferModule,
     ViewOfferAccomodationModule,
+    BackToListModule,
   ],
   exports: [ViewOfferAccommodationComponent],
 })

--- a/src/app/find-help/view-offer-accommodation/view-offer-accommodation.routing.module.ts
+++ b/src/app/find-help/view-offer-accommodation/view-offer-accommodation.routing.module.ts
@@ -6,6 +6,7 @@ const routes: Routes = [
   {
     path: '',
     component: ViewOfferAccommodationComponent,
+    data: { title: null },
   },
 ];
 

--- a/src/app/find-help/view-offer-material-aid/view-offer-material-aid.component.html
+++ b/src/app/find-help/view-offer-material-aid/view-offer-material-aid.component.html
@@ -32,7 +32,7 @@
       <p>{{ data.description }}</p>
     </div>
     <div class="disclaimer mb-3">{{ "CHANGE_LANG_SITE_DISCLAIMER" | translate }}</div>
-    <a (click)="navigateBack()">&lt; {{ "BACK_TO_LIST" | translate }}</a>
+    <app-back-to-list [categoryRouteName]="categoryRouteName"></app-back-to-list>
   </mat-card>
   <div class="w-100 w-md-50">
     <app-reply-offer

--- a/src/app/find-help/view-offer-material-aid/view-offer-material-aid.component.ts
+++ b/src/app/find-help/view-offer-material-aid/view-offer-material-aid.component.ts
@@ -17,8 +17,7 @@ export class ViewOfferMaterialAidComponent implements OnInit {
   constructor(
     private router: Router,
     private route: ActivatedRoute,
-    private materialAidResourceService: MaterialAidResourceService,
-    private storeUrlService: StoreUrlService
+    private materialAidResourceService: MaterialAidResourceService
   ) {}
 
   ngOnInit(): void {
@@ -31,12 +30,6 @@ export class ViewOfferMaterialAidComponent implements OnInit {
       .writeText(this.router.url)
       .then()
       .catch((e) => console.error(e));
-  }
-
-  navigateBack(): void {
-    this.router.navigate([this.router.url.replace(/\/[^/]+$/, '')], {
-      queryParams: this.storeUrlService.getParams(this.categoryRouteName),
-    });
   }
 
   getMaterialAidOffer() {

--- a/src/app/find-help/view-offer-material-aid/view-offer-material-aid.module.ts
+++ b/src/app/find-help/view-offer-material-aid/view-offer-material-aid.module.ts
@@ -11,6 +11,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { ReplyOfferModule } from '../reply-offer/reply-offer.module';
 import { ViewOfferMaterialAidComponent } from './view-offer-material-aid.component';
 import { ViewOfferMaterialAidRoutingModule } from './view-offer-material-aid.routing.module';
+import { BackToListModule } from '@app/shared/components/back-to-list/back-to-list.module';
 
 @NgModule({
   declarations: [ViewOfferMaterialAidComponent],
@@ -26,6 +27,7 @@ import { ViewOfferMaterialAidRoutingModule } from './view-offer-material-aid.rou
     MatIconModule,
     ReplyOfferModule,
     ViewOfferMaterialAidRoutingModule,
+    BackToListModule,
   ],
   exports: [ViewOfferMaterialAidComponent],
 })

--- a/src/app/find-help/view-offer-material-aid/view-offer-material-aid.routing.module.ts
+++ b/src/app/find-help/view-offer-material-aid/view-offer-material-aid.routing.module.ts
@@ -6,6 +6,9 @@ const routes: Routes = [
   {
     path: '',
     component: ViewOfferMaterialAidComponent,
+    data: {
+      title: null,
+    },
   },
 ];
 

--- a/src/app/find-help/view-offer-transport/view-offer-transport.component.html
+++ b/src/app/find-help/view-offer-transport/view-offer-transport.component.html
@@ -47,7 +47,7 @@
       <p>{{ data.description }}</p>
     </div>
     <div class="disclaimer mb-3">{{ "CHANGE_LANG_SITE_DISCLAIMER" | translate }}</div>
-    <a (click)="navigateBack()">&lt; {{ "BACK_TO_LIST" | translate }}</a>
+    <app-back-to-list [categoryRouteName]="categoryRouteName"></app-back-to-list>
   </mat-card>
   <div class="w-100 w-md-50">
     <app-reply-offer

--- a/src/app/find-help/view-offer-transport/view-offer-transport.component.ts
+++ b/src/app/find-help/view-offer-transport/view-offer-transport.component.ts
@@ -18,8 +18,7 @@ export class ViewOfferTransportComponent implements OnInit {
   constructor(
     private router: Router,
     private route: ActivatedRoute,
-    private transportResourceService: TransportResourceService,
-    private storeUrlService: StoreUrlService
+    private transportResourceService: TransportResourceService
   ) {}
 
   ngOnInit(): void {
@@ -32,12 +31,6 @@ export class ViewOfferTransportComponent implements OnInit {
       .writeText(this.router.url)
       .then()
       .catch((e) => console.error(e));
-  }
-
-  navigateBack(): void {
-    this.router.navigate([this.router.url.replace(/\/[^/]+$/, '')], {
-      queryParams: this.storeUrlService.getParams(this.categoryRouteName),
-    });
   }
 
   getTransportOffer() {

--- a/src/app/find-help/view-offer-transport/view-offer-transport.module.ts
+++ b/src/app/find-help/view-offer-transport/view-offer-transport.module.ts
@@ -11,6 +11,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { ReplyOfferModule } from '../reply-offer/reply-offer.module';
 import { ViewOfferTransportComponent } from './view-offer-transport.component';
 import { ViewOfferTransportRoutingModule } from './view-offer-transport.routing.module';
+import { BackToListModule } from '@app/shared/components/back-to-list/back-to-list.module';
 
 @NgModule({
   declarations: [ViewOfferTransportComponent],
@@ -26,6 +27,7 @@ import { ViewOfferTransportRoutingModule } from './view-offer-transport.routing.
     MatIconModule,
     ReplyOfferModule,
     ViewOfferTransportRoutingModule,
+    BackToListModule,
   ],
   exports: [ViewOfferTransportComponent],
 })

--- a/src/app/find-help/view-offer-transport/view-offer-transport.routing.module.ts
+++ b/src/app/find-help/view-offer-transport/view-offer-transport.routing.module.ts
@@ -8,6 +8,7 @@ const routes: Routes = [
   {
     path: '',
     component: ViewOfferTransportComponent,
+    data: { title: null },
   },
 ];
 

--- a/src/app/give-help/accommodation-form/accomodation-form.routing.module.ts
+++ b/src/app/give-help/accommodation-form/accomodation-form.routing.module.ts
@@ -6,6 +6,9 @@ const routes: Routes = [
   {
     path: '',
     component: AccommodationFormComponent,
+    data: {
+      title: null,
+    },
   },
 ];
 

--- a/src/app/give-help/give-help-routing.module.ts
+++ b/src/app/give-help/give-help-routing.module.ts
@@ -10,11 +10,17 @@ const routes: Routes = [
     path: '',
     component: GiveHelpComponent,
     canActivate: [AuthGuard],
+    data: {
+      title: null,
+    },
     children: [
       {
         path: '',
         redirectTo: CategoryRoutingName.ACCOMMODATION,
         pathMatch: 'full',
+        data: {
+          title: null,
+        },
       },
       {
         path: CategoryRoutingName.ACCOMMODATION,

--- a/src/app/give-help/material-aid-form/material-aid-form-routing.module.ts
+++ b/src/app/give-help/material-aid-form/material-aid-form-routing.module.ts
@@ -6,6 +6,9 @@ const routes: Routes = [
   {
     path: '',
     component: MaterialAidFormComponent,
+    data: {
+      title: null,
+    },
   },
 ];
 

--- a/src/app/give-help/transport-form/transport-form.routing.modue.ts
+++ b/src/app/give-help/transport-form/transport-form.routing.modue.ts
@@ -6,6 +6,7 @@ const routes: Routes = [
   {
     path: '',
     component: TransportFormComponent,
+    data: { title: null },
   },
 ];
 

--- a/src/app/my-account/my-account-routing.module.ts
+++ b/src/app/my-account/my-account-routing.module.ts
@@ -6,8 +6,20 @@ import { MyAccountComponent } from './my-account/my-account.component';
 const routes: Routes = [
   {
     path: '',
+    pathMatch: 'full',
     canActivate: [AuthGuard],
     component: MyAccountComponent,
+    data: {
+      title: null,
+    },
+  },
+  {
+    path: '',
+    canActivate: [AuthGuard],
+    loadChildren: () => import('../find-help/find-help.module').then((m) => m.FindHelpModule),
+    data: {
+      title: null,
+    },
   },
 ];
 

--- a/src/app/my-account/my-account/my-account.component.html
+++ b/src/app/my-account/my-account/my-account.component.html
@@ -27,6 +27,7 @@
           [posted]="announcement.modifiedDate"
           [offerId]="announcement.id!"
           [category]="categoryRoutingName.ACCOMMODATION"
+          [routePathPrefix]="viewAdRoutePrefix"
         >
           <app-search-result-attribute
             *ngIf="announcement.guests"
@@ -57,6 +58,7 @@
           [posted]="announcement.modifiedDate"
           [offerId]="announcement.id!"
           [category]="categoryRoutingName.MATERIAL_HELP"
+          [routePathPrefix]="viewAdRoutePrefix"
         >
           <app-search-result-attribute
             *ngIf="announcement.category"
@@ -83,6 +85,7 @@
           [posted]="announcement.modifiedDate"
           [offerId]="announcement.id!"
           [category]="categoryRoutingName.TRANSPORT"
+          [routePathPrefix]="viewAdRoutePrefix"
         >
           <app-search-result-attribute
             *ngIf="announcement.transportDate"

--- a/src/app/my-account/my-account/my-account.component.ts
+++ b/src/app/my-account/my-account/my-account.component.ts
@@ -28,6 +28,8 @@ export class MyAccountComponent implements OnInit {
   pageRequest: Pageable = {};
   categoryRoutingName = CategoryRoutingName;
 
+  readonly viewAdRoutePrefix = [CorePath.MyAccount];
+
   constructor(
     private router: Router,
     private route: ActivatedRoute,

--- a/src/app/shared/components/back-to-list/back-to-list.component.html
+++ b/src/app/shared/components/back-to-list/back-to-list.component.html
@@ -1,0 +1,1 @@
+<a [routerLink]="backRoute" [queryParams]="queryParams">&lt; {{ "BACK_TO_LIST" | translate }}</a>

--- a/src/app/shared/components/back-to-list/back-to-list.component.spec.ts
+++ b/src/app/shared/components/back-to-list/back-to-list.component.spec.ts
@@ -1,0 +1,73 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { StoreUrlService } from '@app/core/store-url/store-url.service';
+import { CategoryRoutingName, CorePath } from '@app/shared/models';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { BackToListComponent } from './back-to-list.component';
+import { BackToListModule } from './back-to-list.module';
+
+@Component({ template: '' })
+class EmptyComponent {}
+
+describe('BackToListComponent', () => {
+  let component: BackToListComponent;
+  let fixture: ComponentFixture<BackToListComponent>;
+  let router: Router;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BackToListComponent],
+      imports: [
+        BackToListModule,
+        TranslateModule.forRoot(),
+        NoopAnimationsModule,
+        RouterTestingModule.withRoutes([{ path: '**', component: EmptyComponent }]),
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    router = TestBed.inject(Router);
+    fixture = TestBed.createComponent(BackToListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  async function navigate(route: string[]) {
+    await router.navigate(route);
+    fixture.detectChanges();
+    component.ngOnChanges();
+    await fixture.whenStable();
+  }
+
+  describe('inside my-account route', () => {
+    it('should build link to my-account', async () => {
+      await navigate(['foo', CorePath.MyAccount, 'bar']);
+
+      expect(component.backRoute).toEqual(['/', CorePath.MyAccount]);
+      expect(component.queryParams).toBeFalsy();
+    });
+  });
+
+  describe('outside my-account route', () => {
+    it('should build link without the last path segment in original route', async () => {
+      await navigate(['foo', 'bar', '1']);
+
+      expect(component.backRoute).toEqual(['/foo/bar']);
+    });
+
+    it('should display query params based on input category', async () => {
+      const paramsSpy = spyOn(TestBed.inject(StoreUrlService), 'getParams').and.returnValue({ page: 2 });
+
+      component.categoryRouteName = CategoryRoutingName.TRANSPORT;
+      await navigate(['foo', 'bar', '1']);
+
+      expect(paramsSpy).toHaveBeenCalledWith(CategoryRoutingName.TRANSPORT);
+      expect(component.queryParams).toEqual({ page: 2 });
+    });
+  });
+});

--- a/src/app/shared/components/back-to-list/back-to-list.component.ts
+++ b/src/app/shared/components/back-to-list/back-to-list.component.ts
@@ -1,0 +1,29 @@
+import { Component, Input, OnChanges } from '@angular/core';
+import { Params, Router } from '@angular/router';
+import { StoreUrlService } from '@app/core/store-url/store-url.service';
+import { CategoryRoutingName, CorePath } from '@app/shared/models';
+
+@Component({
+  selector: 'app-back-to-list',
+  templateUrl: './back-to-list.component.html',
+  styleUrls: ['./back-to-list.component.scss'],
+})
+export class BackToListComponent implements OnChanges {
+  @Input() categoryRouteName: CategoryRoutingName = CategoryRoutingName.ACCOMMODATION;
+
+  constructor(private readonly router: Router, private readonly storeUrlService: StoreUrlService) {}
+
+  backRoute: string[] = [];
+  queryParams: Params | null = null;
+
+  ngOnChanges() {
+    // if we are in context of "my account", navigate directly to /my-accout instead of 'my-account/category'.
+    if (this.router.url.split('/').includes(CorePath.MyAccount)) {
+      this.backRoute = ['/', CorePath.MyAccount];
+      this.queryParams = null;
+    } else {
+      this.backRoute = [this.router.url.replace(/\/[^/]+$/, '')];
+      this.queryParams = this.storeUrlService.getParams(this.categoryRouteName);
+    }
+  }
+}

--- a/src/app/shared/components/back-to-list/back-to-list.module.ts
+++ b/src/app/shared/components/back-to-list/back-to-list.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { BackToListComponent } from './back-to-list.component';
+
+@NgModule({
+  declarations: [BackToListComponent],
+  imports: [CommonModule, RouterModule, TranslateModule],
+  exports: [BackToListComponent],
+})
+export class BackToListModule {}

--- a/src/app/shared/components/breadcrumbs/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/components/breadcrumbs/breadcrumb/breadcrumb.component.spec.ts
@@ -1,24 +1,169 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Router, Routes } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { BreadcrumbComponent } from './breadcrumb.component';
+
+@Component({ template: '' })
+class EmptyComponent {}
+
+const CATEGORY_ROUTES: Routes = [
+  {
+    path: '',
+    component: EmptyComponent,
+    data: { title: null },
+    children: [
+      {
+        path: 'accommodation',
+        data: { title: 'Accommodation' },
+        children: [
+          {
+            path: '',
+            data: { title: null },
+            children: [
+              {
+                path: '',
+                component: EmptyComponent,
+                data: { title: null },
+              },
+              {
+                path: 'not-found',
+                component: EmptyComponent,
+                data: { title: null },
+              },
+              {
+                path: ':id',
+                data: { title: 'Ad' },
+                children: [
+                  {
+                    path: '',
+                    component: EmptyComponent,
+                    data: { title: null },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+// simplified version of app routes without lazy loading.
+const ROUTES: Routes = [
+  {
+    path: '',
+    component: EmptyComponent,
+    pathMatch: 'full',
+    data: {
+      title: null,
+    },
+  },
+  {
+    path: 'find-help',
+    data: {
+      title: 'Find help',
+    },
+    children: CATEGORY_ROUTES,
+  },
+  {
+    path: 'give-help',
+    data: {
+      title: 'Give help',
+    },
+    children: CATEGORY_ROUTES,
+  },
+];
 
 describe('BreadcrumbComponent', () => {
   let component: BreadcrumbComponent;
   let fixture: ComponentFixture<BreadcrumbComponent>;
+  let router: Router;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [BreadcrumbComponent],
+      declarations: [BreadcrumbComponent, EmptyComponent],
+      imports: [CommonModule, RouterTestingModule.withRoutes(ROUTES), NoopAnimationsModule, TranslateModule.forRoot()],
     }).compileComponents();
   });
 
   beforeEach(() => {
+    router = TestBed.inject(Router);
     fixture = TestBed.createComponent(BreadcrumbComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should display single element breadcrumbs initially', async () => {
     expect(component).toBeTruthy();
+    expect(component.breadcrumbs).toEqual([{ label: 'MAIN_PAGE', url: '' }]);
+  });
+
+  it('should display single element breadcrumbs after navigation to root route', async () => {
+    router.navigateByUrl('/');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.breadcrumbs).toEqual([{ label: 'MAIN_PAGE', url: '' }]);
+  });
+
+  it('should create breadcrumbs for first level route', async () => {
+    router.navigateByUrl('/give-help');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.breadcrumbs).toEqual([
+      { label: 'MAIN_PAGE', url: '' },
+      { label: 'Give help', url: '/give-help' },
+    ]);
+  });
+
+  it('should create breadcrumbs for category level route', async () => {
+    router.navigateByUrl('/find-help/accommodation');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.breadcrumbs).toEqual([
+      { label: 'MAIN_PAGE', url: '' },
+      { label: 'Find help', url: '/find-help' },
+      { label: 'Accommodation', url: '/find-help/accommodation' },
+    ]);
+  });
+
+  it('should create breadcrumbs for detailed route', async () => {
+    router.navigateByUrl('/find-help/accommodation/27');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.breadcrumbs).toEqual([
+      { label: 'MAIN_PAGE', url: '' },
+      { label: 'Find help', url: '/find-help' },
+      { label: 'Accommodation', url: '/find-help/accommodation' },
+      { label: 'Ad', url: '/find-help/accommodation/27' },
+    ]);
+  });
+
+  it('should create breadcrumbs for detailed route containing second route child', async () => {
+    router.navigateByUrl('/give-help/accommodation/27');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.breadcrumbs).toEqual([
+      { label: 'MAIN_PAGE', url: '' },
+      { label: 'Give help', url: '/give-help' },
+      { label: 'Accommodation', url: '/give-help/accommodation' },
+      { label: 'Ad', url: '/give-help/accommodation/27' },
+    ]);
   });
 });

--- a/src/app/shared/components/breadcrumbs/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/components/breadcrumbs/breadcrumb/breadcrumb.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { ActivatedRoute, ActivatedRouteSnapshot, NavigationEnd, Router } from '@angular/router';
 import { distinctUntilChanged, filter, startWith } from 'rxjs';
 import { Breadcrumb, BreadcrumbLabels } from '@app/shared/models';
 
@@ -18,8 +18,7 @@ export class BreadcrumbComponent implements OnInit {
   constructor(private router: Router, private route: ActivatedRoute) {}
 
   public ngOnInit() {
-    const currentUrlAsArray: string[] = this.router.url.split('/').slice(1);
-    this.setBreadcrumbs(currentUrlAsArray);
+    this.breadcrumbs = this.buildBreadcrumbs();
     this.listeningOnRouterEvents();
   }
 
@@ -32,27 +31,34 @@ export class BreadcrumbComponent implements OnInit {
       )
       .subscribe((event) => {
         if (event instanceof NavigationEnd) {
-          this.breadcrumbs = [];
-          const currentUrlAsArray: string[] = event.url.split('/').slice(1);
-          this.setBreadcrumbs(currentUrlAsArray);
+          this.breadcrumbs = this.buildBreadcrumbs();
         }
         this.breadcrumbs = [this.mainPage, ...this.breadcrumbs];
       });
   }
 
-  private setBreadcrumbs(currentUrlAsArray: string[]): void {
-    currentUrlAsArray.forEach((el: string, i: number) => {
-      this.breadcrumbs.push({
-        label: this.route.snapshot.children[i - 1]?.data['title'] || this.route.snapshot.data['title'],
-        url: this.router.url
-          .split('/')
-          .slice(0, i + 2)
-          .join('/'),
-      });
-    });
+  private buildBreadcrumbs(): Breadcrumb[] {
+    const breadcrumbs: Breadcrumb[] = [];
+    let route: ActivatedRouteSnapshot | null = findRootRoute(this.route.snapshot);
+    let path = [];
+    while (route) {
+      const label: string = route.data['title'];
+      const newSegments = route.url.map((segment) => segment.path);
+      path.push(...newSegments);
+      console.log(label, path);
+      if (label) {
+        breadcrumbs.push({ label, url: '/' + path.join('/') });
+      }
+      route = route.firstChild;
+    }
+    return breadcrumbs;
   }
 
   activeRoute(): string {
     return this.router.url;
   }
+}
+
+function findRootRoute(route: ActivatedRouteSnapshot): ActivatedRouteSnapshot {
+  return route.parent == null ? route : findRootRoute(route.parent);
 }

--- a/src/app/shared/models/breadcrumb-labels.model.ts
+++ b/src/app/shared/models/breadcrumb-labels.model.ts
@@ -9,4 +9,5 @@ export enum BreadcrumbLabels {
   ABOUT = 'ABOUT_APP',
   STATEMENT = 'STATEMENT',
   PAGE_NOT_FOUND = 'PAGE_NOT_FOUND',
+  AD = 'AD',
 }

--- a/src/app/statement/statement-routing.module.ts
+++ b/src/app/statement/statement-routing.module.ts
@@ -6,6 +6,7 @@ const routes: Routes = [
   {
     path: '',
     component: StatementComponent,
+    data: { title: null },
   },
 ];
 

--- a/src/app/welcome/welcome-routing.module.ts
+++ b/src/app/welcome/welcome-routing.module.ts
@@ -6,6 +6,9 @@ const routes: Routes = [
   {
     path: '',
     component: WelcomeComponent,
+    data: {
+      title: null,
+    },
   },
 ];
 


### PR DESCRIPTION
Rewrite logic of building breadcrumbs - route.children doesn't return what was expected. Instead we need to recursively traverse the whole route hierarchy.

Also added data: {title: ...} to every route entry. If data is not present in a particual entry, it is taken from parent. This results in duplicated breadcrumbs in some places.

Fixed "back to list" button by extracting it to shared component. It navigates back to "my account" route if it's present in the url, otherwise previous behavior is preserved.