### PR TITLE
POM-241 stylowanie UI - niewłaściwa maska, zasłania tekst (tylko Safari)

### DIFF
--- a/src/app/welcome/dashboard/dashboard.component.scss
+++ b/src/app/welcome/dashboard/dashboard.component.scss
@@ -57,6 +57,7 @@
 
   &-wave {
     position: absolute;
+    width: 100%;
     z-index: 0;
     left: 0;
     bottom: -15px;


### PR DESCRIPTION
POM-241 stylowanie ui niewlasciwa maska zaslania tekst