### PR TITLE
POM-276 Add default query params to the link on category click. 

### DIFF
--- a/src/app/core/store-url/store-url.service.ts
+++ b/src/app/core/store-url/store-url.service.ts
@@ -41,14 +41,18 @@ export class StoreUrlService {
     return this.getPreviousUrl?.includes(routing) ? (params as Params) : null;
   }
 
+  getDefaultQueryParams(): Params {
+    return {
+      page: 0,
+      size: localStorage.getItem(LocalStorageKeys.PageSize) ?? 5,
+      sort: [`modifiedDate,${SortingOrder.descending}`],
+    };
+  }
+
   async setDefaultPaginatorParam(): Promise<void> {
     await this.router.navigate([], {
       relativeTo: this.route,
-      queryParams: {
-        page: 0,
-        size: localStorage.getItem(LocalStorageKeys.PageSize) ?? 5,
-        sort: [`modifiedDate,${SortingOrder.descending}`],
-      },
+      queryParams: this.getDefaultQueryParams(),
       queryParamsHandling: 'merge',
     });
   }

--- a/src/app/find-help/accommodation-search/accommodation-search.component.ts
+++ b/src/app/find-help/accommodation-search/accommodation-search.component.ts
@@ -20,7 +20,7 @@ export class AccommodationSearchComponent implements OnInit {
   constructor(private accommodationsResourceService: AccommodationsResourceService, private route: ActivatedRoute) {}
 
   ngOnInit() {
-    const { page, size, capacity, city, region } = this.route.snapshot.queryParams;
+    const { capacity, city, region } = this.route.snapshot.queryParams;
     const searchCriteria: AccommodationQuery = {
       capacity,
       location: {
@@ -28,9 +28,7 @@ export class AccommodationSearchComponent implements OnInit {
         city,
       },
     };
-    if (page != null || size != null || capacity != null || city != null || region != null) {
-      this.search(searchCriteria);
-    }
+    this.search(searchCriteria);
   }
 
   getResultsObservable(

--- a/src/app/find-help/material-aid-search/material-aid-search.component.ts
+++ b/src/app/find-help/material-aid-search/material-aid-search.component.ts
@@ -19,7 +19,7 @@ export class MaterialAidSearchComponent implements OnInit {
   constructor(private materialAidResourceService: MaterialAidResourceService, private route: ActivatedRoute) {}
 
   ngOnInit() {
-    const { page, size, category, city, region } = this.route.snapshot.queryParams;
+    const { category, city, region } = this.route.snapshot.queryParams;
     const searchCriteria: MaterialAidOfferSearchCriteria = {
       category,
       location: {
@@ -27,9 +27,7 @@ export class MaterialAidSearchComponent implements OnInit {
         city,
       },
     };
-    if (page != null || size != null || category != null || city != null || region != null) {
-      this.search(searchCriteria);
-    }
+    this.search(searchCriteria);
   }
 
   search(searchCriteria?: MaterialAidOfferSearchCriteria) {

--- a/src/app/find-help/transport-search/transport-search.component.ts
+++ b/src/app/find-help/transport-search/transport-search.component.ts
@@ -19,7 +19,7 @@ export class TransportSearchComponent implements OnInit {
   constructor(private transportResourceService: TransportResourceService, private route: ActivatedRoute) {}
 
   ngOnInit() {
-    const { page, size, capacity, transportDate, originCity, originRegion, destinationCity, destinationRegion } =
+    const { capacity, transportDate, originCity, originRegion, destinationCity, destinationRegion } =
       this.route.snapshot.queryParams;
     const searchCriteria: TransportOfferSearchCriteria = {
       capacity,
@@ -33,18 +33,7 @@ export class TransportSearchComponent implements OnInit {
         city: destinationCity,
       },
     };
-    if (
-      page != null ||
-      size != null ||
-      capacity != null ||
-      transportDate != null ||
-      originCity != null ||
-      originRegion != null ||
-      destinationCity != null ||
-      destinationRegion != null
-    ) {
-      this.search(searchCriteria);
-    }
+    this.search(searchCriteria);
   }
 
   search(searchCriteria?: TransportOfferSearchCriteria) {

--- a/src/app/shared/components/category-navigation/category-navigation.component.html
+++ b/src/app/shared/components/category-navigation/category-navigation.component.html
@@ -5,6 +5,7 @@
         *ngIf="!category.disabled"
         class="category-link"
         [routerLink]="['/', outputPath, routingCategoryName[category.name]]"
+        [queryParams]="queryParams()"
       >
         <app-type-of-help
           [icon]="category.icon"

--- a/src/app/shared/components/category-navigation/category-navigation.component.ts
+++ b/src/app/shared/components/category-navigation/category-navigation.component.ts
@@ -3,7 +3,7 @@ import { Category, CategoryNameKey, CategoryRoutingName, CorePath } from '@app/s
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
-import { Router, RouterModule } from '@angular/router';
+import { Params, Router, RouterModule } from '@angular/router';
 import { TypeOfHelpComponentModule } from '@app/shared/components';
 import { StoreUrlService } from '@app/core/store-url';
 
@@ -33,7 +33,7 @@ export class CategoryNavigationComponent {
     return this.router.url.split('/')[2];
   }
 
-  queryParams() {
+  queryParams(): Params {
     return this.storeUrlService.getDefaultQueryParams();
   }
 }

--- a/src/app/shared/components/category-navigation/category-navigation.component.ts
+++ b/src/app/shared/components/category-navigation/category-navigation.component.ts
@@ -5,6 +5,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
 import { Router, RouterModule } from '@angular/router';
 import { TypeOfHelpComponentModule } from '@app/shared/components';
+import { StoreUrlService } from '@app/core/store-url';
 
 @Component({
   selector: 'app-category-navigation',
@@ -26,10 +27,14 @@ export class CategoryNavigationComponent {
     { name: CategoryNameKey.MISC, icon: 'lan', disabled: true },
   ];
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private storeUrlService: StoreUrlService) {}
 
   activeRoute(): string | undefined {
     return this.router.url.split('/')[2];
+  }
+
+  queryParams() {
+    return this.storeUrlService.getDefaultQueryParams();
   }
 }
 


### PR DESCRIPTION
Also removes conditions for executing search on init. This way even if link does not contain query parameters, a search query without filters will be executed. This seems to be handled well by backend.

This PR is a replacement for #138 .