### PR TITLE
POM-294 Zachowywanie stanu wyszukanych wyników podczas nawigacji pomiędzy ogłoszeniami

### DIFF
--- a/src/app/core/store-url/store-url.service.ts
+++ b/src/app/core/store-url/store-url.service.ts
@@ -35,7 +35,7 @@ export class StoreUrlService {
       ?.split('&')
       .map((item) => item.split('='))
       .reduce((acc: Record<string, string>, param: string[]) => {
-        acc[param[0]] = param[1];
+        acc[param[0]] = decodeURI(param[1]);
         return acc;
       }, {});
     return this.getPreviousUrl?.includes(routing) ? (params as Params) : null;


### PR DESCRIPTION
Zachowywanie stanu wyszukanych wyników podczas nawigacji pomiędzy ogłoszeniami

Fixed:
Lista zostaje zachowana co jest super i znacznie już poprawia ten case. Jednakże po wciśnięciu wstecz znika z pola wybrane wcześniej miasto wkartach noclegi i transport. Użytkownik chcąc zmienić miasto może się zdziwić brakiem kursora w polu. Po chwili pewnie dostrzeże "X" obok. 