### PR TITLE
POM-393 Urwanie linku w nowym tabie przeglądarki

### DIFF
--- a/src/app/find-help/view-offer-accommodation/view-offer-accommodation.component.ts
+++ b/src/app/find-help/view-offer-accommodation/view-offer-accommodation.component.ts
@@ -28,7 +28,7 @@ export class ViewOfferAccommodationComponent implements OnInit {
   ) {
     // https://stackoverflow.com/questions/54891110/router-getcurrentnavigation-always-returns-null
     // in constructor, because null will be returned in ngOnInit
-    this.redirectedFromAccount = this.router.getCurrentNavigation()?.extras?.state!['redirectFromAccount'];
+    this.redirectedFromAccount = !!this.router.getCurrentNavigation()?.extras?.state?.['redirectFromAccount'];
   }
 
   ngOnInit(): void {

--- a/src/app/find-help/view-offer-material-aid/view-offer-material-aid.component.ts
+++ b/src/app/find-help/view-offer-material-aid/view-offer-material-aid.component.ts
@@ -23,7 +23,7 @@ export class ViewOfferMaterialAidComponent implements OnInit {
   ) {
     // https://stackoverflow.com/questions/54891110/router-getcurrentnavigation-always-returns-null
     // in constructor, because null will be returned in ngOnInit
-    this.redirectedFromAccount = this.router.getCurrentNavigation()?.extras?.state!['redirectFromAccount'];
+    this.redirectedFromAccount = !!this.router.getCurrentNavigation()?.extras?.state?.['redirectFromAccount'];
   }
 
   ngOnInit(): void {

--- a/src/app/find-help/view-offer-transport/view-offer-transport.component.ts
+++ b/src/app/find-help/view-offer-transport/view-offer-transport.component.ts
@@ -24,7 +24,7 @@ export class ViewOfferTransportComponent implements OnInit {
   ) {
     // https://stackoverflow.com/questions/54891110/router-getcurrentnavigation-always-returns-null
     // in constructor, because null will be returned in ngOnInit
-    this.redirectedFromAccount = this.router.getCurrentNavigation()?.extras?.state!['redirectFromAccount'];
+    this.redirectedFromAccount = !!this.router.getCurrentNavigation()?.extras?.state?.['redirectFromAccount'];
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
https://jira.sysopspolska.pl/browse/POM-393

Przy wklejaniu pełnego linka w przeglądarkę, extras był  `undefined` i konstruktory tych komponentów rzucały błędem i triggerowały `NavigationError` event. 