### PR TITLE
[refactoring, low priority] Extract offer title input from create ad form components to shared component

### DIFF
--- a/src/app/give-help/accommodation-form/accommodation-form.component.html
+++ b/src/app/give-help/accommodation-form/accommodation-form.component.html
@@ -3,25 +3,7 @@
     <div class="container">
       <div class="row">
         <div class="col-md-12">
-          <label>
-            <b>{{ "LABEL_OFFER_TITLE" | translate }}</b>
-            <span> {{ "LABEL_OFFER_MAXCHARS" | translate }} *</span>
-          </label>
-          <mat-form-field appearance="outline">
-            <input
-              matInput
-              maxlength="80"
-              placeholder="{{ 'PLACEHOLDER_OFFER_TITLE' | translate }}"
-              required
-              name="title"
-              [(ngModel)]="data.title"
-              #title="ngModel"
-              appOfferTitleValidate
-            />
-            <mat-error>
-              <app-field-error [model]="title"></app-field-error>
-            </mat-error>
-          </mat-form-field>
+          <app-offer-title-input [(value)]="data.title"></app-offer-title-input>
         </div>
       </div>
       <div class="row">

--- a/src/app/give-help/give-help-form/give-help-form.module.ts
+++ b/src/app/give-help/give-help-form/give-help-form.module.ts
@@ -4,10 +4,22 @@ import { PublishAdButtonComponent } from './publish-ad-button/publish-ad-button.
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
+import { OfferTitleInputComponent } from './offer-title-input/offer-title-input.component';
+import { MatInputModule } from '@angular/material/input';
+import { FieldErrorModule } from '@app/shared/components';
+import { ValidatorsDirectivesModule } from '@app/shared/validators';
 
 @NgModule({
-  declarations: [PublishAdButtonComponent],
-  exports: [PublishAdButtonComponent],
-  imports: [CommonModule, FormsModule, MatIconModule, TranslateModule],
+  declarations: [PublishAdButtonComponent, OfferTitleInputComponent],
+  exports: [PublishAdButtonComponent, OfferTitleInputComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatIconModule,
+    TranslateModule,
+    MatInputModule,
+    FieldErrorModule,
+    ValidatorsDirectivesModule,
+  ],
 })
 export class GiveHelpFormModule {}

--- a/src/app/give-help/give-help-form/offer-title-input/offer-title-input.component.html
+++ b/src/app/give-help/give-help-form/offer-title-input/offer-title-input.component.html
@@ -1,0 +1,20 @@
+<label>
+  <b>{{ "LABEL_OFFER_TITLE" | translate }}</b>
+  <span> {{ "LABEL_OFFER_MAXCHARS" | translate }} *</span>
+</label>
+<mat-form-field appearance="outline">
+  <input
+    matInput
+    maxlength="80"
+    placeholder="{{ 'PLACEHOLDER_OFFER_TITLE' | translate }}"
+    required
+    name="title"
+    [ngModel]="value"
+    (ngModelChange)="valueChange.emit($event)"
+    #title="ngModel"
+    appOfferTitleValidate
+  />
+  <mat-error>
+    <app-field-error [model]="title"></app-field-error>
+  </mat-error>
+</mat-form-field>

--- a/src/app/give-help/give-help-form/offer-title-input/offer-title-input.component.spec.ts
+++ b/src/app/give-help/give-help-form/offer-title-input/offer-title-input.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OfferTitleInputComponent } from './offer-title-input.component';
+
+describe('OfferTitleInputComponent', () => {
+  let component: OfferTitleInputComponent;
+  let fixture: ComponentFixture<OfferTitleInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [OfferTitleInputComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OfferTitleInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/give-help/give-help-form/offer-title-input/offer-title-input.component.ts
+++ b/src/app/give-help/give-help-form/offer-title-input/offer-title-input.component.ts
@@ -1,0 +1,15 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ControlContainer, NgForm } from '@angular/forms';
+
+/** The component is expected to be used inside <form>. */
+@Component({
+  selector: 'app-offer-title-input',
+  templateUrl: './offer-title-input.component.html',
+  styleUrls: ['./offer-title-input.component.scss'],
+  // Needed to attach the input to the parent form.
+  viewProviders: [{ provide: ControlContainer, useExisting: NgForm }],
+})
+export class OfferTitleInputComponent {
+  @Input() value: string = '';
+  @Output() valueChange = new EventEmitter<string>();
+}

--- a/src/app/give-help/material-aid-form/material-aid-form.component.html
+++ b/src/app/give-help/material-aid-form/material-aid-form.component.html
@@ -2,25 +2,7 @@
   <form (submit)="handleSubmit()" #materialAidForm="ngForm">
     <div class="row">
       <div class="col-md-12">
-        <label>
-          <b>{{ "LABEL_OFFER_TITLE" | translate }}</b>
-          <span> {{ "LABEL_OFFER_MAXCHARS" | translate }} *</span>
-        </label>
-        <mat-form-field appearance="outline">
-          <input
-            matInput
-            maxlength="80"
-            placeholder="{{ 'PLACEHOLDER_OFFER_TITLE' | translate }}"
-            required
-            name="title"
-            [(ngModel)]="data.title"
-            #title="ngModel"
-            appOfferTitleValidate
-          />
-          <mat-error>
-            <app-field-error [model]="title"></app-field-error>
-          </mat-error>
-        </mat-form-field>
+        <app-offer-title-input [(value)]="data.title"></app-offer-title-input>
       </div>
     </div>
     <div class="row">

--- a/src/app/give-help/transport-form/transport-form.component.html
+++ b/src/app/give-help/transport-form/transport-form.component.html
@@ -3,25 +3,7 @@
     <div class="container">
       <div class="row">
         <div class="col-md-12">
-          <label>
-            <b>{{ "LABEL_OFFER_TITLE" | translate }}</b>
-            <span> {{ "LABEL_OFFER_MAXCHARS" | translate }} *</span>
-          </label>
-          <mat-form-field appearance="outline">
-            <input
-              matInput
-              maxlength="80"
-              placeholder="{{ 'PLACEHOLDER_OFFER_TITLE' | translate }}"
-              required
-              name="title"
-              [(ngModel)]="data.title"
-              #title="ngModel"
-              appOfferTitleValidate
-            />
-            <mat-error>
-              <app-field-error [model]="title"></app-field-error>
-            </mat-error>
-          </mat-form-field>
+          <app-offer-title-input [(value)]="data.title"></app-offer-title-input>
         </div>
       </div>
 


### PR DESCRIPTION
I've experimented a bit with extracting duplicated form controls. 
This approach looks simpler than implementing ControlValueAccessor and works well with template-driven forms.
