### PR TITLE
POM-409 Backdrop dodany, wyjście z okienka kliknięciem zablokowane

### DIFF
--- a/src/app/my-account/my-account/my-account.component.ts
+++ b/src/app/my-account/my-account/my-account.component.ts
@@ -64,10 +64,11 @@ export class MyAccountComponent implements OnInit {
 
   removeAnnouncement(announcement: AccommodationOffer | MaterialAidOffer | TransportOffer): void {
     const dialogRef: MatDialogRef<ConfirmRemoveAdComponent> = this.dialog.open(ConfirmRemoveAdComponent, {
-      hasBackdrop: false,
+      hasBackdrop: true,
       width: '100%',
       maxHeight: '450px',
       maxWidth: '720px',
+      disableClose: true,
     });
 
     dialogRef.componentInstance.currentAnnouncement = announcement;


### PR DESCRIPTION
Problem był w tym, że mając otwartę okienko można było klikać w przyciski w aplikacjia, i tak na przykład otworzyć wiele modali usuń.

Na makietach mamy też rozmyty backdrop, także wziąłem domyślny jako odpowiednik.