### PR TITLE
POM-292 Introduce PolicyLink component. Use in footer and ad reply.

### DIFF
--- a/src/app/core/site-footer/site-footer.module.ts
+++ b/src/app/core/site-footer/site-footer.module.ts
@@ -4,10 +4,11 @@ import { SiteFooterComponent } from './site-footer/site-footer.component';
 import { PomCommonPipesModule } from '@app/shared/pipes';
 import { RouterModule } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
+import { PolicyLinkModule } from '@app/shared/components/policy-link/policy-link.module';
 
 @NgModule({
   declarations: [SiteFooterComponent],
   exports: [SiteFooterComponent],
-  imports: [CommonModule, PomCommonPipesModule, RouterModule, TranslateModule],
+  imports: [CommonModule, PolicyLinkModule, PomCommonPipesModule, RouterModule, TranslateModule],
 })
 export class SiteFooterModule {}

--- a/src/app/core/site-footer/site-footer/site-footer.component.html
+++ b/src/app/core/site-footer/site-footer/site-footer.component.html
@@ -18,14 +18,7 @@
         }}</a>
         <a href="https://pomagamukrainie.gov.pl/konwoj" class="navbar-item">{{ "HUMANITY_TRANSPORT" | translate }}</a>
         <a [routerLink]="corePath.Statement" class="navbar-item">{{ "STATEMENT" | translate }}</a>
-        <a
-          [href]="
-            'https://pomagamukrainie.gov.pl/assets/rodo/politykaprywatnosci' + getSuffixForTranslatedResource() + '.pdf'
-          "
-          target="_blank"
-          class="navbar-item"
-          >{{ "POLICY" | translate }}</a
-        >
+        <app-policy-link [denominator]="true"></app-policy-link>
         <a [routerLink]="[corePath.About]" class="navbar-item">{{ "ABOUT_APP" | translate }}</a>
       </nav>
     </div>

--- a/src/app/core/site-footer/site-footer/site-footer.component.ts
+++ b/src/app/core/site-footer/site-footer/site-footer.component.ts
@@ -1,7 +1,5 @@
 import { Component } from '@angular/core';
 import { CorePath } from '@app/shared/models';
-import { LanguageCode } from '@app/core/translations';
-import { LocalStorageKeys } from '@app/shared/models';
 
 @Component({
   selector: 'app-site-footer',
@@ -11,19 +9,4 @@ import { LocalStorageKeys } from '@app/shared/models';
 export class SiteFooterComponent {
   corePath = CorePath;
   constructor() {}
-
-  getSuffixForTranslatedResource(): string {
-    const code = localStorage.getItem(LocalStorageKeys.LangOption) || LanguageCode.pl_PL;
-    switch (code) {
-      case LanguageCode.en_GB:
-        return '_EN';
-      case LanguageCode.uk_UA:
-        return '_UK';
-      case LanguageCode.ru_RU:
-        return '_RU';
-      default:
-        // Polish translation handled as a spec-rule. Aligning: TODO in MVP2.
-        return '';
-    }
-  }
 }

--- a/src/app/find-help/reply-offer/reply-offer.component.html
+++ b/src/app/find-help/reply-offer/reply-offer.component.html
@@ -69,15 +69,9 @@
           (change)="onConsentChange()"
           name="consent"
         >
-          <span>{{ "ACCEPT" | translate }} </span>
-          <a target="_blank" href=""
-            ><span>{{ "CONSENT" | translate }}</span></a
-          >
           <span *ngIf="!authService.isLoggedIn()">
-            <span> {{ "AND" | translate }} </span>
-            <a target="_blank" href="https://pomagamukrainie.gov.pl/assets/rodo/politykaprywatnosci.pdf"
-              ><span>{{ "PRIVATE_POLICY" | translate }}</span></a
-            >
+            {{ "ACCEPT" | translate }}
+            <app-policy-link [denominator]="false"></app-policy-link>
           </span>
         </mat-checkbox>
       </div>

--- a/src/app/find-help/reply-offer/reply-offer.module.ts
+++ b/src/app/find-help/reply-offer/reply-offer.module.ts
@@ -13,6 +13,7 @@ import { FieldErrorModule } from '@app/shared/components';
 import { ValidatorsDirectivesModule } from '@app/shared/validators';
 import { RECAPTCHA_V3_SITE_KEY, RecaptchaV3Module } from 'ng-recaptcha';
 import { environment } from 'src/environments/environment';
+import { PolicyLinkModule } from '@app/shared/components/policy-link/policy-link.module';
 
 @NgModule({
   declarations: [ReplyOfferComponent],
@@ -29,6 +30,7 @@ import { environment } from 'src/environments/environment';
     FieldErrorModule,
     ValidatorsDirectivesModule,
     RecaptchaV3Module,
+    PolicyLinkModule,
   ],
   exports: [ReplyOfferComponent],
   providers: [

--- a/src/app/shared/components/policy-link/policy-link.component.html
+++ b/src/app/shared/components/policy-link/policy-link.component.html
@@ -1,9 +1,8 @@
 <a
-[href]="
-  'https://pomagamukrainie.gov.pl/assets/rodo/politykaprywatnosci' + getSuffixForTranslatedResource() + '.pdf'
-"
-target="_blank"
-class="navbar-item">
-<ng-template [ngIf]="denominator">{{ "POLICY" | translate }}</ng-template>
-<ng-template [ngIf]="!denominator">{{ "PRIVATE_POLICY" | translate }}</ng-template>
+  [href]="'https://pomagamukrainie.gov.pl/assets/rodo/politykaprywatnosci' + getSuffixForTranslatedResource() + '.pdf'"
+  target="_blank"
+  class="navbar-item"
+>
+  <ng-template [ngIf]="denominator">{{ "POLICY" | translate }}</ng-template>
+  <ng-template [ngIf]="!denominator">{{ "PRIVATE_POLICY" | translate }}</ng-template>
 </a>

--- a/src/app/shared/components/policy-link/policy-link.component.html
+++ b/src/app/shared/components/policy-link/policy-link.component.html
@@ -1,0 +1,9 @@
+<a
+[href]="
+  'https://pomagamukrainie.gov.pl/assets/rodo/politykaprywatnosci' + getSuffixForTranslatedResource() + '.pdf'
+"
+target="_blank"
+class="navbar-item">
+<ng-template [ngIf]="denominator">{{ "POLICY" | translate }}</ng-template>
+<ng-template [ngIf]="!denominator">{{ "PRIVATE_POLICY" | translate }}</ng-template>
+</a>

--- a/src/app/shared/components/policy-link/policy-link.component.html
+++ b/src/app/shared/components/policy-link/policy-link.component.html
@@ -3,6 +3,5 @@
   target="_blank"
   class="navbar-item"
 >
-  <ng-template [ngIf]="denominator">{{ "POLICY" | translate }}</ng-template>
-  <ng-template [ngIf]="!denominator">{{ "PRIVATE_POLICY" | translate }}</ng-template>
+  {{ (denominator ? "POLICY" : "PRIVATE_POLICY") | translate }}
 </a>

--- a/src/app/shared/components/policy-link/policy-link.component.spec.ts
+++ b/src/app/shared/components/policy-link/policy-link.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { NotFoundComponent } from './polich-link.component';
+
+describe('NotFoundComponent', () => {
+  let component: PolicyLinkComponent;
+  let fixture: ComponentFixture<PolicyLinkComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule, TranslateModule.forRoot()],
+      declarations: [PolicyLinkComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PolicyLinkComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/policy-link/policy-link.component.ts
+++ b/src/app/shared/components/policy-link/policy-link.component.ts
@@ -1,0 +1,33 @@
+import { Component, Input, OnChanges } from '@angular/core';
+import { Params, Router } from '@angular/router';
+import { StoreUrlService } from '@app/core/store-url/store-url.service';
+import { CategoryRoutingName, CorePath } from '@app/shared/models';
+import { LanguageCode } from '@app/core/translations';
+import { LocalStorageKeys } from '@app/shared/models';
+
+@Component({
+  selector: 'app-policy-link',
+  templateUrl: './policy-link.component.html',
+  styleUrls: ['./policy-link.component.scss'],
+})
+export class PolicyLinkComponent {
+  corePath = CorePath;
+
+  // TODO: introduce grammatical cases, starting with denominator and accusative.
+  @Input() denominator: boolean = true;
+
+  getSuffixForTranslatedResource(): string {
+    const code = localStorage.getItem(LocalStorageKeys.LangOption) || LanguageCode.pl_PL;
+    switch (code) {
+      case LanguageCode.en_GB:
+        return '_EN';
+      case LanguageCode.uk_UA:
+        return '_UK';
+      case LanguageCode.ru_RU:
+        return '_RU';
+      default:
+        // Polish translation handled as a spec-rule. Aligning: TODO in MVP2.
+        return '';
+    }
+  }
+}

--- a/src/app/shared/components/policy-link/policy-link.module.ts
+++ b/src/app/shared/components/policy-link/policy-link.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { PolicyLinkComponent } from './policy-link.component';
+
+@NgModule({
+  declarations: [PolicyLinkComponent],
+  imports: [CommonModule, RouterModule, TranslateModule],
+  exports: [PolicyLinkComponent],
+})
+export class PolicyLinkModule {}


### PR DESCRIPTION
The component renders html link to a pdf in the correct
language, and with the label in correct gramatical case.

The component is used in:
* footer
* offer reply for a not logged user.