### PR TITLE
POM-402 [UC.03] Mobile, po wejściu w informator szerokość strony jest…

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -2,8 +2,11 @@
 
 .page-layout {
   min-height: 100vh;
-  display: grid;
-  grid-template-rows: auto 1fr auto;
+  display: flex;
+  flex-direction: column;
+  main {
+    flex-grow: 1;
+  }
 }
 .content {
   display: flex;


### PR DESCRIPTION
… nie dostosowana do ekranu.

https://jira.sysopspolska.pl/browse/POM-402

wygląda na to, że css grid coś psuł przy liczeniu szerokości akordeonów, zmieniłem na flexbox.

![screen-capture](https://user-images.githubusercontent.com/46559156/160200747-1c32969b-32c0-40ee-9b3e-3c3107d7fb40.gif)


![Screenshot 2022-03-25 214242](https://user-images.githubusercontent.com/46559156/160200073-6a151dd1-44c4-4ea8-866c-c0b6d74aaa8f.JPG)

## weryfikacja kilku innych ekranów:


![Screenshot 2022-03-25 213725](https://user-images.githubusercontent.com/46559156/160200112-aabe0059-f786-45de-a45b-19fcefc48005.JPG)
![Screenshot 2022-03-25 214328](https://user-images.githubusercontent.com/46559156/160200115-957bfef7-f74d-4290-b841-505c8a2a3499.JPG)
![Screenshot 2022-03-25 215029](https://user-images.githubusercontent.com/46559156/160200117-7ffd8f50-5712-430f-94b4-dc9320d1681a.JPG)
![Screenshot 2022-03-25 215050](https://user-images.githubusercontent.com/46559156/160200119-d2576170-6514-4b48-9c34-85d35c1b86ac.JPG)

