### PR TITLE
POM-421 - usuniecie linkow do informatora, moduł i komponent zostaje

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -44,13 +44,6 @@ const routes: Routes = [
     },
   },
   {
-    path: CorePath.Statement,
-    loadChildren: () => import('./statement/statement.module').then((m) => m.StatementModule),
-    data: {
-      title: BreadcrumbLabels.STATEMENT,
-    },
-  },
-  {
     path: '**',
     component: PageNotFoundComponent,
     loadChildren: () =>

--- a/src/app/core/site-footer/site-footer/site-footer.component.html
+++ b/src/app/core/site-footer/site-footer/site-footer.component.html
@@ -17,7 +17,6 @@
           "HELP_FOR_UKRAINE" | translate
         }}</a>
         <a href="https://pomagamukrainie.gov.pl/konwoj" class="navbar-item">{{ "HUMANITY_TRANSPORT" | translate }}</a>
-        <a [routerLink]="corePath.Statement" class="navbar-item">{{ "STATEMENT" | translate }}</a>
         <app-policy-link [denominator]="true"></app-policy-link>
         <a (click)="viewAbout()" class="navbar-item">{{ "ABOUT_APP" | translate }}</a>
       </nav>

--- a/src/app/core/site-header/site-header.component.html
+++ b/src/app/core/site-header/site-header.component.html
@@ -53,14 +53,6 @@
               </li>
               <li
                 (click)="closeMenu()"
-                class="navbar-item navbar-big"
-                data-bs-toggle="collapse"
-                data-bs-target=".navbar-collapse.show"
-              >
-                <a class="navbar-link" (click)="viewStatement()">{{ "STATEMENT" | translate }}</a>
-              </li>
-              <li
-                (click)="closeMenu()"
                 class="navbar-item navbar-big mobile-only"
                 data-bs-toggle="collapse"
                 data-bs-target=".navbar-collapse.show"

--- a/src/app/core/site-header/site-header.component.ts
+++ b/src/app/core/site-header/site-header.component.ts
@@ -81,10 +81,4 @@ export class SiteHeaderComponent {
   public get isAccountUrl(): boolean {
     return this.router.url.includes(CorePath.MyAccount);
   }
-
-  viewStatement() {
-    this.router.navigate([CorePath.Statement]).then(() => {
-      this.viewportScroller.scrollToPosition([0, 0]);
-    });
-  }
 }

--- a/src/app/find-help/accommodation-search/accommodation-search-form/accommodation-search-form.component.html
+++ b/src/app/find-help/accommodation-search/accommodation-search-form/accommodation-search-form.component.html
@@ -37,6 +37,5 @@
         </button>
       </div>
     </div>
-    <app-more-info-link [statementAnchor]="statementAnchor"></app-more-info-link>
   </div>
 </form>

--- a/src/app/find-help/material-aid-search/material-aid-search-form/material-aid-search-form.component.html
+++ b/src/app/find-help/material-aid-search/material-aid-search-form/material-aid-search-form.component.html
@@ -32,6 +32,5 @@
         </button>
       </div>
     </div>
-    <app-more-info-link [statementAnchor]="statementAnchor"></app-more-info-link>
   </div>
 </form>

--- a/src/app/find-help/transport-search/transport-search-form/transport-search-form.component.html
+++ b/src/app/find-help/transport-search/transport-search-form/transport-search-form.component.html
@@ -53,6 +53,5 @@
         </button>
       </div>
     </div>
-    <app-more-info-link [statementAnchor]="statementAnchor"></app-more-info-link>
   </div>
 </form>

--- a/src/app/shared/components/no-results/no-results.component.html
+++ b/src/app/shared/components/no-results/no-results.component.html
@@ -1,8 +1,3 @@
 <div class="no-results">
   <h5>{{ "NO_RESULTS_HEADER" | translate }}</h5>
-  <p>
-    {{ "NO_RESULTS_TEXT_START" | translate }}
-    <a [routerLink]="['/' + corePath.Statement]" class="font-blue">{{ "NO_RESULTS_TEXT_LINK" | translate }}</a>
-    {{ "NO_RESULTS_TEXT_END" | translate }}
-  </p>
 </div>

--- a/src/app/shared/components/not-found/not-found.component.html
+++ b/src/app/shared/components/not-found/not-found.component.html
@@ -7,8 +7,5 @@
   </p>
   <p>
     <a [routerLink]="['..']" class="font-blue">{{ "NOT_FOUND_NEXT_ACTION" | translate }}</a>
-    {{ "NOT_FOUND_NEXT_ACTION_OR" | translate }}
-    <a [routerLink]="['/', corePath.Statement]" class="font-blue">{{ "NO_RESULTS_TEXT_LINK" | translate }}</a>
-    {{ "NO_RESULTS_TEXT_END" | translate }}
   </p>
 </div>

--- a/src/app/shared/components/page-not-found/page-not-found.component.html
+++ b/src/app/shared/components/page-not-found/page-not-found.component.html
@@ -10,8 +10,6 @@
     <p>{{ "PAGE_NOT_FOUND_LONG" | translate }}</p>
     <p>
       <a [routerLink]="['/', corePath.Find]" class="font-blue">{{ "PAGE_NOT_FOUND_NEXT_ACTION" | translate }}</a>
-      {{ "NOT_FOUND_NEXT_ACTION_OR" | translate }}
-      <a [routerLink]="['/', corePath.Statement]" class="font-blue">{{ "NO_RESULTS_TEXT_LINK" | translate }}</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
Usuwam linkowanie do informatora, 
app-more-info-link pozostaje w modułach
jeśli wrócimy do informatora to zrobimy revert