### PR TITLE
POM-433 Capitalize all words in cities' names

### DIFF
--- a/src/app/shared/components/cities-search/display-location-option.ts
+++ b/src/app/shared/components/cities-search/display-location-option.ts
@@ -20,8 +20,11 @@ export function displayLocationOption(location?: Location) {
   return toTitleCase(location.city) + ', ' + location.region;
 
   function toTitleCase(value: string) {
-    // DO NOT replace it with `value[0].toUpperCase()` etc. as that may not
-    // select the whole glyph, unlike unicode regex replacement.
-    return value.toLowerCase().replace(/^./u, (letter) => letter.toUpperCase());
+    // ^. - first character of the string
+    // \s. - first character after whitespace
+    // -. - first character after - (f.e. Kudowa-Zdroj)
+    return value
+      .toLowerCase()
+      .replace(/(^.|\s.|-.)([A-Za-zĄąĆćĘęŁłŃńÓóŚśŹźŻż]*)/g, (_, m1, m2) => m1.toUpperCase() + m2.toLowerCase());
   }
 }

--- a/src/app/shared/components/cities-search/display-location-option.ts
+++ b/src/app/shared/components/cities-search/display-location-option.ts
@@ -23,8 +23,6 @@ export function displayLocationOption(location?: Location) {
     // ^. - first character of the string
     // \s. - first character after whitespace
     // -. - first character after - (f.e. Kudowa-Zdroj)
-    return value
-      .toLowerCase()
-      .replace(/(^.|\s.|-.)([A-Za-zĄąĆćĘęŁłŃńÓóŚśŹźŻż]*)/g, (_, m1, m2) => m1.toUpperCase() + m2.toLowerCase());
+    return value.toLowerCase().replace(/(^.|\s.|-.)([^-\s]*)/g, (_, m1, m2) => m1.toUpperCase() + m2);
   }
 }

--- a/src/app/shared/components/cities-search/display-location-option.ts
+++ b/src/app/shared/components/cities-search/display-location-option.ts
@@ -23,6 +23,6 @@ export function displayLocationOption(location?: Location) {
     // ^. - first character of the string
     // \s. - first character after whitespace
     // -. - first character after - (f.e. Kudowa-Zdroj)
-    return value.toLowerCase().replace(/(^.|\s.|-.)([^-\s]*)/g, (_, m1, m2) => m1.toUpperCase() + m2);
+    return value.toLowerCase().replace(/(^.|\s.|-.)([^-\s]*)/gu, (_, m1, m2) => m1.toUpperCase() + m2);
   }
 }


### PR DESCRIPTION
According to POM-433 

Capitalizing all words in city names (f.e. Warszawa, Kazimierz Dolny, Kudowa-Zdrój) 