### PR TITLE
POM-464 Improvement of category navigation (inactive mode)

### DIFF
--- a/src/app/shared/components/category-navigation/category-navigation.component.html
+++ b/src/app/shared/components/category-navigation/category-navigation.component.html
@@ -1,34 +1,36 @@
 <nav class="navigation">
   <div class="categories">
     <ng-container *ngFor="let category of categories">
-      <a
-        *ngIf="!category.disabled"
-        class="category-link"
-        [routerLink]="['/', outputPath, routingCategoryName[category.name]]"
-        [queryParams]="queryParams()"
-      >
-        <app-type-of-help
-          [icon]="category.icon"
-          [name]="category.name"
-          [selected]="isActive(category)"
-          [disabled]="category.disabled"
+      <ng-container *ngIf="!category.disabled && !(inactive && !isActive(category)); else disabledCategory">
+        <a
+          class="category-link"
+          [routerLink]="['/', outputPath, routingCategoryName[category.name]]"
+          [queryParams]="queryParams()"
         >
-        </app-type-of-help>
-      </a>
-      <div
-        *ngIf="category.disabled"
-        [matTooltip]="'AVAILABLE_SOON' | translate"
-        matTooltipClass="tooltip-white"
-        matTooltipPosition="before"
-      >
-        <app-type-of-help
-          [icon]="category.icon"
-          [name]="category.name"
-          [selected]="isActive(category)"
-          [disabled]="category.disabled"
+          <app-type-of-help
+            [icon]="category.icon"
+            [name]="category.name"
+            [selected]="isActive(category)"
+            [disabled]="category.disabled"
+          >
+          </app-type-of-help>
+        </a>
+      </ng-container>
+      <ng-template #disabledCategory>
+        <div
+          [matTooltip]="category.disabled && !inactive ? ('AVAILABLE_SOON' | translate) : undefined"
+          matTooltipClass="tooltip-white"
+          matTooltipPosition="before"
         >
-        </app-type-of-help>
-      </div>
+          <app-type-of-help
+            [icon]="category.icon"
+            [name]="category.name"
+            [selected]="isActive(category)"
+            [disabled]="category.disabled || (inactive && !isActive(category))"
+          >
+          </app-type-of-help>
+        </div>
+      </ng-template>
     </ng-container>
   </div>
 </nav>

--- a/src/app/shared/components/category-navigation/category-navigation.component.ts
+++ b/src/app/shared/components/category-navigation/category-navigation.component.ts
@@ -15,6 +15,7 @@ import { MAT_TOOLTIP_DEFAULT_OPTIONS, MatTooltipDefaultOptions, MatTooltipModule
 })
 export class CategoryNavigationComponent {
   @Input() outputPath: CorePath = CorePath.Find;
+  @Input() inactive: boolean = false;
   routingCategoryName = CategoryRoutingName;
 
   categories: Category[] = [


### PR DESCRIPTION
PR adds `inactive mode` to `app-category-navigation` component. 
Inactive mode can be used to present current type of announcement without navigation ability. (f.e. on editing announcement screen).

Attention: The PR contains only improvement of component. After merging [`Edit announcement` feature](https://github.com/coi-gov-pl/gui-web-pomogamukrainie-forum/pull/282), you need to fulfill new input on the basis of special flag

 **Default mode (inactive: false) :**

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/10097549/162811610-67840402-c592-4068-baeb-b51b0529391c.png">

**Inactive mode:**

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/10097549/162811940-c4821f97-1827-493d-9d4f-174e31e59bca.png">

