### PR TITLE
[POM-565] Clear filters visual change

### DIFF
--- a/src/app/find-help/accommodation-search/accommodation-search-form/accommodation-search-form.component.html
+++ b/src/app/find-help/accommodation-search/accommodation-search-form/accommodation-search-form.component.html
@@ -31,12 +31,17 @@
         </mat-form-field>
       </div>
       <div class="form-search-wrapper d-md-flex col-md-4">
-        <div class="d-flex flex-column align-items-stretch align-items-md-center ms-md-4">
+        <div class="d-flex flex-column align-items-stretch align-items-md-center ms-md-4 buttons-mt-md">
           <button type="submit" class="btn btn-dark" [disabled]="form.invalid">
             <mat-icon fontSet="material-icons-outlined">search</mat-icon>
             <span>{{ "SEARCH" | translate }}</span>
           </button>
-          <button *ngIf="showClearBtn" type="button" class="form-clear-filters btn btn-link" (click)="clearFilters()">
+          <button
+            [ngStyle]="{ visibility: showClearBtn ? 'visible' : 'hidden' }"
+            type="button"
+            class="form-clear-filters btn btn-link"
+            (click)="clearFilters()"
+          >
             <span>{{ "CLEAR_FILTERS" | translate }}</span>
           </button>
         </div>

--- a/src/app/find-help/health-search/health-search-form/health-search-form.component.html
+++ b/src/app/find-help/health-search/health-search-form/health-search-form.component.html
@@ -55,12 +55,17 @@
         </mat-form-field>
       </div>
       <div class="form-search-wrapper d-xl-flex col-xl-2">
-        <div class="d-flex flex-column align-items-stretch align-items-md-center ms-xl-4">
+        <div class="d-flex flex-column align-items-stretch align-items-md-center ms-xl-4 buttons-mt-xl">
           <button type="submit" class="btn btn-dark" [disabled]="form.invalid">
             <mat-icon fontSet="material-icons-outlined">search</mat-icon>
             <span>{{ "SEARCH" | translate }}</span>
           </button>
-          <button *ngIf="showClearBtn" type="button" class="form-clear-filters btn btn-link" (click)="clearFilters()">
+          <button
+            [ngStyle]="{ visibility: showClearBtn ? 'visible' : 'hidden' }"
+            type="button"
+            class="form-clear-filters btn btn-link"
+            (click)="clearFilters()"
+          >
             <span>{{ "CLEAR_FILTERS" | translate }}</span>
           </button>
         </div>

--- a/src/app/find-help/job-search/job-search-form/job-search-form.component.html
+++ b/src/app/find-help/job-search/job-search-form/job-search-form.component.html
@@ -1,4 +1,4 @@
-<form class="d-flex flex-column flex-md-row align-items-center" (ngSubmit)="onSubmit()" #form="ngForm">
+<form class="d-flex flex-column flex-xl-row align-items-center" (ngSubmit)="onSubmit()" #form="ngForm">
   <div class="container">
     <div class="row">
       <div class="col-md-6">
@@ -81,12 +81,17 @@
     </div>
   </div>
   <div class="form-search-wrapper">
-    <div class="d-flex flex-column align-items-stretch align-items-md-center ms-md-4">
+    <div class="d-flex flex-column align-items-stretch align-items-md-center ms-xl-4 buttons-mt-xl">
       <button type="submit" class="btn btn-dark" [disabled]="form.invalid">
         <mat-icon fontSet="material-icons-outlined">search</mat-icon>
         <span>{{ "SEARCH" | translate }}</span>
       </button>
-      <button *ngIf="showClearBtn" type="button" class="form-clear-filters btn btn-link" (click)="clearFilters()">
+      <button
+        [ngStyle]="{ visibility: showClearBtn ? 'visible' : 'hidden' }"
+        type="button"
+        class="form-clear-filters btn btn-link"
+        (click)="clearFilters()"
+      >
         <span>{{ "CLEAR_FILTERS" | translate }}</span>
       </button>
     </div>

--- a/src/app/find-help/law-search/law-search-form/law-search-form.component.html
+++ b/src/app/find-help/law-search/law-search-form/law-search-form.component.html
@@ -53,12 +53,17 @@
         </mat-form-field>
       </div>
       <div class="form-search-wrapper d-xl-flex col-xl-2">
-        <div class="d-flex flex-column align-items-stretch align-items-md-center ms-xl-4">
+        <div class="d-flex flex-column align-items-stretch align-items-md-center ms-xl-4 buttons-mt-xl">
           <button type="submit" class="btn btn-dark" [disabled]="form.invalid">
             <mat-icon fontSet="material-icons-outlined">search</mat-icon>
             <span>{{ "SEARCH" | translate }}</span>
           </button>
-          <button *ngIf="showClearBtn" type="button" class="form-clear-filters btn btn-link" (click)="clearFilters()">
+          <button
+            [ngStyle]="{ visibility: showClearBtn ? 'visible' : 'hidden' }"
+            type="button"
+            class="form-clear-filters btn btn-link"
+            (click)="clearFilters()"
+          >
             <span>{{ "CLEAR_FILTERS" | translate }}</span>
           </button>
         </div>

--- a/src/app/find-help/material-aid-search/material-aid-search-form/material-aid-search-form.component.html
+++ b/src/app/find-help/material-aid-search/material-aid-search-form/material-aid-search-form.component.html
@@ -26,12 +26,17 @@
         ></app-cities-search>
       </div>
       <div class="form-search-wrapper d-md-flex col-md-4">
-        <div class="d-flex flex-column align-items-stretch align-items-md-center ms-md-4">
+        <div class="d-flex flex-column align-items-stretch align-items-md-center ms-md-4 buttons-mt-md">
           <button type="submit" class="btn btn-dark" [disabled]="form.invalid">
             <mat-icon fontSet="material-icons-outlined">search</mat-icon>
             <span>{{ "SEARCH" | translate }}</span>
           </button>
-          <button *ngIf="showClearBtn" type="button" class="form-clear-filters btn btn-link" (click)="clearFilters()">
+          <button
+            [ngStyle]="{ visibility: showClearBtn ? 'visible' : 'hidden' }"
+            type="button"
+            class="form-clear-filters btn btn-link"
+            (click)="clearFilters()"
+          >
             <span>{{ "CLEAR_FILTERS" | translate }}</span>
           </button>
         </div>

--- a/src/app/find-help/transport-search/transport-search-form/transport-search-form.component.html
+++ b/src/app/find-help/transport-search/transport-search-form/transport-search-form.component.html
@@ -51,12 +51,17 @@
         </mat-form-field>
       </div>
       <div class="form-search-wrapper d-md-flex col-md-8 col-lg-3">
-        <div class="d-flex flex-column align-items-stretch align-items-md-center ms-md-4">
+        <div class="d-flex flex-column align-items-stretch align-items-md-center ms-md-4 buttons-mt-md">
           <button type="submit" class="btn btn-dark" [disabled]="form.invalid">
             <mat-icon fontSet="material-icons-outlined">search</mat-icon>
             <span>{{ "SEARCH" | translate }}</span>
           </button>
-          <button *ngIf="showClearBtn" type="button" class="form-clear-filters btn btn-link" (click)="clearFilters()">
+          <button
+            [ngStyle]="{ visibility: showClearBtn ? 'visible' : 'hidden' }"
+            type="button"
+            class="form-clear-filters btn btn-link"
+            (click)="clearFilters()"
+          >
             <span>{{ "CLEAR_FILTERS" | translate }}</span>
           </button>
         </div>

--- a/src/assets/styles/forms.scss
+++ b/src/assets/styles/forms.scss
@@ -48,4 +48,16 @@ form {
 .form-search-wrapper {
   align-items: center;
   justify-content: flex-end;
+
+  .buttons-mt-xl {
+    @media (min-width: $breakpoint-xl) {
+      margin-top: 1.42rem;
+    }
+  }
+
+  .buttons-mt-md {
+    @media (min-width: $breakpoint-md) {
+      margin-top: 1.42rem;
+    }
+  }
 }


### PR DESCRIPTION
Przycisk 'wyczyść filtry' już nie skacze, jego położenie wygląda tak jak zostało opisane w zgłoszeniu.