### PR TITLE
POM-538 Align header logo and nav

### DIFF
--- a/src/app/core/site-header/site-header.component.html
+++ b/src/app/core/site-header/site-header.component.html
@@ -6,17 +6,17 @@
           <span class="visually-hidden">{{ "MAIN_PAGE" | translate }}</span>
           <img class="navbar-brand herb" [src]="'herb.png' | path: 'imagesPath'" alt="herb" />
         </a>
-        <span class="desktop-only header-element">
+        <span class="d-none d-md-inline header-element">
           <a href="/" class="navbar-brand">
             <span class="visually-hidden">{{ "MAIN_PAGE" | translate }}</span>
             <img
-              class="logo"
+              class="kprm"
               [src]="'kprm.svg' | path: 'imagesPath'"
               [alt]="'CHANCELLERY_OF_PRIME_MINISTER' | translate"
             />
           </a>
         </span>
-        <span class="desktop-only header-element">
+        <span class="d-none d-md-inline header-element">
           <a href="/" class="navbar-brand">
             <span class="visually-hidden">{{ "MAIN_PAGE" | translate }}</span>
             <img class="logo" [src]="'pomagamyua.svg' | path: 'imagesPath'" [alt]="'MAIN_PAGE' | translate" />

--- a/src/app/core/site-header/site-header.component.scss
+++ b/src/app/core/site-header/site-header.component.scss
@@ -174,10 +174,12 @@
   }
 
   &-menu {
-    background: transparent;
+    background-color: var(--c-darkblue);
+    border-radius: 0;
     border: none;
-    padding-left: 0;
-    min-width: 115px;
+    padding: 0;
+    min-width: 140px;
+    margin-top: 25px;
   }
   &-toggle {
     border: none;
@@ -198,7 +200,7 @@
     cursor: pointer;
     font-size: 18px;
     font-weight: 700;
-    padding: 0.4rem 0.625rem;
+    padding: 8px 15px;
 
     &:hover {
       border-color: var(--c-lightblue);

--- a/src/app/core/site-header/site-header.component.scss
+++ b/src/app/core/site-header/site-header.component.scss
@@ -5,7 +5,12 @@
   position: relative;
 
   .right-side {
-    margin-right: -16px;
+    margin-left: auto;
+    margin-right: 35px;
+
+    @include media-breakpoint-up(lg) {
+      margin-right: -16px;
+    }
   }
 
   header {
@@ -25,18 +30,21 @@
     width: 100%;
     .logo,
     .herb {
-      width: 45px;
+      width: 51px;
+    }
+    .kprm {
+      width: 60px;
     }
     &-brand {
       display: flex;
       align-items: center;
+      margin-right: 36px;
     }
   }
 }
 
 .navbar {
   &-item {
-    border-bottom: 2px solid transparent;
     font-size: 18px;
     font-weight: 700;
     padding: 0.4rem 1rem;


### PR DESCRIPTION
- set size logo same as hompage
- language dropdown background

Przed:
![obraz](https://user-images.githubusercontent.com/101187771/167367658-88dd7ab2-ea49-4083-af00-354afe5e677b.png)

Po:
![obraz](https://user-images.githubusercontent.com/101187771/167367475-0340d0b0-de3f-4c06-bcb1-2fa338574051.png)
