### PR TITLE
[POM-497] fix for cropped separators in breadcrumbs

### DIFF
--- a/src/app/shared/components/breadcrumbs/breadcrumb/breadcrumb.component.scss
+++ b/src/app/shared/components/breadcrumbs/breadcrumb/breadcrumb.component.scss
@@ -1,6 +1,6 @@
 .breadcrumb {
   &-item {
-    margin-top: 4px;
+    margin: 1px;
     font-size: 13px;
     letter-spacing: -0.1px;
     font-family: var(--font-open-sans);


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/12514322/167402677-cda00f69-b58d-4ab7-a828-86f5e6516116.png)

![image](https://user-images.githubusercontent.com/12514322/167402656-1429fb68-6b3f-42fc-83b5-898ebae54c54.png)
